### PR TITLE
Compiler test

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -182,9 +182,6 @@ jobs:
 
             $CC --version
             $CXX --version
-
-            echo "CC=$CC" >> "$GITHUB_OUTPUT"
-            echo "CXX=$CXX" >> "$GITHUB_OUTPUT"
           else
             wget https://apt.llvm.org/llvm.sh
             chmod +x llvm.sh
@@ -195,10 +192,10 @@ jobs:
 
             $CC --version
             $CXX --version
-
-            echo "CC=$CC" >> "$GITHUB_OUTPUT"
-            echo "CXX=$CXX" >> "$GITHUB_OUTPUT"
           fi
+
+          echo "CC=$CC" >> "$GITHUB_OUTPUT"
+          echo "CXX=$CXX" >> "$GITHUB_OUTPUT"
       - name: Configure CMake
         run: |
           cmake -B build -S . -DCMAKE_CXX_STANDARD=20

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -147,8 +147,6 @@ jobs:
       matrix:
         compilers:
           - class: GNU
-            version: 15
-          - class: GNU
             version: 14
           - class: GNU
             version: 13
@@ -177,12 +175,7 @@ jobs:
             CC=gcc-${{ matrix.compilers.version }}
             CXX=g++-${{ matrix.compilers.version }}
 
-            if [ "${{ matrix.compilers.version}}" = "15" ]; then
-              sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-            else
-              sudo add-apt-repository universe
-            fi
-
+            sudo add-apt-repository universe
             sudo apt-get update
             sudo apt-get install -y $CC
             sudo apt-get install -y $CXX

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -147,8 +147,6 @@ jobs:
       matrix:
         compilers:
           - class: GNU
-            version: 15
-          - class: GNU
             version: 14
     name: "Compiler: ${{ matrix.compilers.class }} ${{ matrix.compilers.version }}"
     steps:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -152,6 +152,8 @@ jobs:
             version: 13
           - class: GNU
             version: 12
+          - class: LLVM
+            version: 20
     name: "Compiler: ${{ matrix.compilers.class }} ${{ matrix.compilers.version }}"
     steps:
       - uses: actions/checkout@v4
@@ -182,8 +184,14 @@ jobs:
             chmod +x llvm.sh
             sudo bash llvm.sh ${{ matrix.compilers.version }}
 
-            clang-${{ matrix.compilers.version }} --version
-            clang++-${{ matrix.compilers.version }} --version
+            CC=clang-${{ matrix.compilers.version }}
+            CXX=clang++-${{ matrix.compilers.version }}
+
+            $CC --version
+            $CXX --version
+
+            echo "CC=$CC" >> "$GITHUB_OUTPUT"
+            echo "CXX=$CXX" >> "$GITHUB_OUTPUT"
           fi
       - name: Configure CMake
         run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -172,18 +172,14 @@ jobs:
           CC: gcc
           CXX: g++
           CMAKE_GENERATOR: "Ninja Multi-Config"
-      - name: Build Release
-        run: |
-          cmake --build build --config Release --verbose
-          cmake --build build --config Release --target all_verify_interface_header_sets
-          cmake --install build --config Release --prefix /opt/beman.exemplar
-          find /opt/beman.exemplar -type f
       - name: Build Debug
         run: |
           cmake --build build --config Debug --verbose
           cmake --build build --config Debug --target all_verify_interface_header_sets
           cmake --install build --config Debug --prefix /opt/beman.exemplar
           find /opt/beman.exemplar -type f
+      - name: Test Debug
+        run: ctest --test-dir build --build-config Debug
 
 
   create-issue-when-fault:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -160,21 +160,37 @@ jobs:
         with:
           cmakeVersion: "~3.25.0"
           ninjaVersion: "^1.11.1"
-      - name: Install GCC
+      - name: Install Compiler
+        id: install-compiler
         run: |
-          sudo add-apt-repository universe
-          sudo apt-get update
-          sudo apt-get install -y gcc-${{ matrix.compilers.version }}
-          sudo apt-get install -y g++-${{ matrix.compilers.version }}
+          if [ "${{ matrix.compilers.class }}" = "GNU" ]; then
+            CC=gcc-${{ matrix.compilers.version }}
+            CXX=g++-${{ matrix.compilers.version }}
 
-          gcc-${{ matrix.compilers.version }} --version
-          g++-${{ matrix.compilers.version }} --version
+            sudo add-apt-repository universe
+            sudo apt-get update
+            sudo apt-get install -y $CC
+            sudo apt-get install -y $CXX
+
+            $CC --version
+            $CXX --version
+
+            echo "CC=$CC" >> "$GITHUB_OUTPUT"
+            echo "CXX=$CXX" >> "$GITHUB_OUTPUT"
+          else
+            wget https://apt.llvm.org/llvm.sh
+            chmod +x llvm.sh
+            sudo bash llvm.sh ${{ matrix.compilers.version }}
+
+            clang-${{ matrix.compilers.version }} --version
+            clang++-${{ matrix.compilers.version }} --version
+          fi
       - name: Configure CMake
         run: |
           cmake -B build -S . -DCMAKE_CXX_STANDARD=20
         env:
-          CC: gcc
-          CXX: g++
+          CC: ${{ steps.install-compiler.outputs.CC }}
+          CXX: ${{ steps.install-compiler.outputs.CXX }}
           CMAKE_GENERATOR: "Ninja Multi-Config"
       - name: Build Debug
         run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -141,9 +141,56 @@ jobs:
           cmake --install build --config Debug --prefix /opt/beman.exemplar
           find /opt/beman.exemplar -type f
 
+  compiler-test:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        compilers:
+          - class: GNU
+            version: 15
+          - class: GNU
+            version: 14
+    name: "Compiler: ${{ matrix.compilers.class }} ${{ matrix.compilers.version }}"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup build environment
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.25.0"
+          ninjaVersion: "^1.11.1"
+      - name: Install GCC
+        run: |
+          sudo add-apt-repository universe
+          sudo apt-get update
+          sudo apt-get install -y gcc-${{ matrix.compilers.version }}
+          sudo apt-get install -y g++-${{ matrix.compilers.version }}
+
+          gcc-${{ matrix.compilers.version }} --version
+          g++-${{ matrix.compilers.version }} --version
+      - name: Configure CMake
+        run: |
+          cmake -B build -S . -DCMAKE_CXX_STANDARD=20
+        env:
+          CC: gcc
+          CXX: g++
+          CMAKE_GENERATOR: "Ninja Multi-Config"
+      - name: Build Release
+        run: |
+          cmake --build build --config Release --verbose
+          cmake --build build --config Release --target all_verify_interface_header_sets
+          cmake --install build --config Release --prefix /opt/beman.exemplar
+          find /opt/beman.exemplar -type f
+      - name: Build Debug
+        run: |
+          cmake --build build --config Debug --verbose
+          cmake --build build --config Debug --target all_verify_interface_header_sets
+          cmake --install build --config Debug --prefix /opt/beman.exemplar
+          find /opt/beman.exemplar -type f
+
+
   create-issue-when-fault:
     runs-on: ubuntu-latest
-    needs: [preset-test, gtest-test, configuration-test]
+    needs: [preset-test, gtest-test, configuration-test, compiler-test]
     if: failure() && github.event_name == 'schedule'
     steps:
       # See https://github.com/cli/cli/issues/5075

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -154,6 +154,12 @@ jobs:
             version: 12
           - class: LLVM
             version: 20
+          - class: LLVM
+            version: 19
+          - class: LLVM
+            version: 18
+          - class: LLVM
+            version: 17
     name: "Compiler: ${{ matrix.compilers.class }} ${{ matrix.compilers.version }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -147,6 +147,8 @@ jobs:
       matrix:
         compilers:
           - class: GNU
+            version: 15
+          - class: GNU
             version: 14
           - class: GNU
             version: 13
@@ -175,7 +177,12 @@ jobs:
             CC=gcc-${{ matrix.compilers.version }}
             CXX=g++-${{ matrix.compilers.version }}
 
-            sudo add-apt-repository universe
+            if [ "${{ matrix.compilers.version}}" = "15" ]; then
+              sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+            else
+              sudo add-apt-repository universe
+            fi
+
             sudo apt-get update
             sudo apt-get install -y $CC
             sudo apt-get install -y $CXX

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -148,6 +148,10 @@ jobs:
         compilers:
           - class: GNU
             version: 14
+          - class: GNU
+            version: 13
+          - class: GNU
+            version: 12
     name: "Compiler: ${{ matrix.compilers.class }} ${{ matrix.compilers.version }}"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Implement trivial cases for #73 .

By trivial I mean either available from package managers (GCC), or via officially supported install script (LLVM).

Included versions:

GCC:
- 14
- 13
- 12
Note: Lower versions are generally available on apt. GCC 15 mentioned in #73 is not available due to no official release. 

LLVM:
- 20
- 19
- 18
- 17
Note: Lower versions (#73 requests 16) is not available from llvm's official script as it is no longer supported. See: https://github.com/llvm/llvm-project/issues/90536

This adds 7 new CI jobs.

As GCC/ Clang doesn't publish their nightly build on package managers, using nightly/ head of compiler will need us to build either a custom image or be tested in a nightly job.


Note: A more complicated but CI-wide salable approach using custom build docker image is being experimented.
Instead of pulling various versions of compiler on every CI run, we use a pre-built docker image that has all compilers install.
See: https://github.com/wusatosi/cpp-docker/ for an example of docker image, we can speed this up by having multiple kinds of image.
See: https://github.com/wusatosi/exemplar/tree/compiler-test-docker as a proof of concept on exemplar side implementation.
See: https://github.com/wusatosi/exemplar/actions/runs/12216494307/job/34079670273 as an example of actions run.