### PR TITLE
Remove BUILD_TESTING variable setting for GTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ if(BEMAN_EXEMPLAR_BUILD_TESTS)
     )
     block()
         set(INSTALL_GTEST OFF) # Disable GoogleTest installation
-        set(BUILD_TESTING OFF) # Disable GoogleTest tests
         FetchContent_MakeAvailable(googletest)
     endblock()
 endif()


### PR DESCRIPTION
This variable doesn't control whether or not tests are built in the googletest repository. See https://github.com/google/googletest/blob/35d0c365609296fa4730d62057c487e3cfa030ff/googletest/CMakeLists.txt#L18