### PR TITLE
remove unnecessary comments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -8,25 +6,16 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
-
-    # Clang-format for C++
-    # This brings in a portable version of clang-format.
-    # See also: https://github.com/ssciwr/clang-format-wheel
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.8
     hooks:
     - id: clang-format
       types_or: [c++, c]
-
-    # CMake linting and formatting
   - repo: https://github.com/BlankSpruce/gersemi
     rev: 0.15.1
     hooks:
     - id: gersemi
       name: CMake linting
-
-    # Markdown linting
-    # Config file: .markdownlint.yaml
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.42.0
     hooks:


### PR DESCRIPTION
These comments add clutter in my opinion. If someone is editing this file,
they can search google to learn more information about pre-commit. We
don't, for example, link to the CMake homepage from our CMakeLists.txt.

Additionally, the other comments here are pieces of reference documentation
elsewhere.
