### PR TITLE
beman.exemplar: change library status to under development (exemplar is a template library)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # beman.exemplar: A Beman Library Exemplar
 
+![Library Status](https://github.com/bemanproject/beman/blob/c6997986557ec6dda98acbdf502082cdf7335526/images/badges/beman_badge-beman_library_under_development.svg)
 ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg)
+![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md).
 This can be used as a template for those intending to write Beman libraries.
 It may also find use as a minimal and modern  C++ project structure.
 
-Implements: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
+**Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
+
+**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
 ## Usage
 


### PR DESCRIPTION
Issues: https://github.com/bemanproject/beman/issues/77

Expected README.md:

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/76c923b2-b366-4257-abe8-291214ab45a6" />

