### PR TITLE
Define the `test` build target more often

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ project(
     LANGUAGES CXX
 )
 
+enable_testing()
+
 # [CMAKE.SKIP_TESTS]
 option(
     BEMAN_EXEMPLAR_BUILD_TESTS
@@ -27,8 +29,6 @@ include(FetchContent)
 include(GNUInstallDirs)
 
 if(BEMAN_EXEMPLAR_BUILD_TESTS)
-    enable_testing()
-
     # Fetch GoogleTest
     FetchContent_Declare(
         googletest


### PR DESCRIPTION
Problem
-------

Given a setting of `BEMAN_EXEMPLAR_BUILD_TESTS` equal to `OFF`, when a user runs a basic CMake test command such as:

```
cmake --build binary-dir/ --target test
```

Then the user gets an error that indicates there is no CMake test target defined.

```
$ cmake --build build2/ --target test
ninja: error: unknown target 'test', did you mean 'help'?
```

Solution
--------

It is not required to actually build any tests to define the CMake test target. This commit defines the CMake `test` target unconditionally.

This is good practice for a few reasons:

* A user or tool doesn't have to know project-specific details to perform basic actions on this project.

* A user or tool doesn't have to know how to interpret the "unknown target 'test'" error.

* When no tests are built, the user sees a successful run of zero tests instead of a more ambiguous situation where test aren't run for unclear reasons.