### PR TITLE
Support system libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,14 +31,14 @@ include(GNUInstallDirs)
 if(BEMAN_EXEMPLAR_BUILD_TESTS)
     # Fetch GoogleTest
     FetchContent_Declare(
-        googletest
+        GTest
         GIT_REPOSITORY https://github.com/google/googletest.git
         GIT_TAG
             f8d7d77c06936315286eb55f8de22cd23c188571 # release-1.14.0
         EXCLUDE_FROM_ALL
     )
     set(INSTALL_GTEST OFF) # Disable GoogleTest installation
-    FetchContent_MakeAvailable(googletest)
+    FetchContent_MakeAvailable(GTest)
 endif()
 
 add_subdirectory(src/beman/exemplar)

--- a/README.md
+++ b/README.md
@@ -325,6 +325,30 @@ cmake -B build -S . -DBEMAN_EXEMPLAR_BUILD_TESTING=OFF
 
 </details>
 
+<details>
+<summary> Disable `git clone` operations </summary>
+
+By default, while tests are enabled, this project will clone GoogleTest
+and build it from source. In many environments, it is better to use an
+already available GoogleTest instead.
+
+### Existing Source Code
+
+For instance, in Ubuntu, source code for GoogleTest is provided via a
+debian-style package under the directory `/usr/src/googletest`. To
+use those sources instead of cloning other sources from the internet,
+provide `-DFETCHCONTENT_SOURCE_DIR_GTEST=/usr/src/googletest` as a
+configuration argument when calling `cmake`.
+
+### Existing Binaries
+
+In another case, again in Ubuntu, GoogleTest can be installed prebuilt
+with CMake discovery support deployed in normal search paths.
+Setting `-DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS` when calling `cmake`
+will force the build of this project to locate that installed library.
+
+</details>
+
 ## Integrate beman.exemplar into your project
 
 <details>
@@ -378,6 +402,7 @@ Build systems that support `pkg-config` by providing a `beman.exemplar.pc` file.
 Build systems that support interoperation via `pkg-config` should be able to detect `beman.exemplar` for you automatically.
 
 </details>
+
 
 ## Contributing
 


### PR DESCRIPTION
Problem
-------

**Given**:

A sandbox environment is an environment where dependencies
are all provided but access to the internet is not. Also take as
a given that the build for this project happens in an environment
that meets that description.
    
**When**:
    
Configuring this project with any of the provided approaches. For
instance:
    
```
cmake -B build -S .
```
    
**Then**:
    
The configuration step hangs or fails, depending on the nature of
the sandboxed environment.
    
Solution
--------
    
Alter `FetchContent_*` calls in this project to use `GTest` as the
project name and nothing else. This is important to allow the
`FETCHCONENT_TRY_FIND_PACKAGE_MODE` feature to work as designed.
This allows the human or tool building this project to explicitly
disable operations involving calls to `git` or other off-box I/O.
    
The documentation in the README was also updated to include
workflow tweaks for building against packaged versions of either
existing GoogleTest source code or prebuilt GoogleTest libraries.