### PR TITLE
Bring into compliance with [CMAKE.SKIP_TESTS] section of Beman Standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,16 @@ project(example
   DESCRIPTION "An example Beman library"
   LANGUAGES CXX
 )
-include(CTest)
+
+option(
+    BEMAN_EXAMPLE_BUILD_TESTING
+    "Enable building tests and test infrastructure. Default: ON. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
 
 add_subdirectory(src/example)
 
-if (BUILD_TESTING)
+if (BEMAN_EXAMPLE_BUILD_TESTING)
+  enable_testing()
   add_subdirectory(test/example)
 endif ()


### PR DESCRIPTION
This commit replaces the use of BUILD_TESTING with a BEMAN_EXAMPLE_BUILD_TESTING option that is enabled by default iff the project is not being included by another project, as recommended by the Beman Standard.