### PR TITLE
Add appleclang testing to CI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -122,7 +122,7 @@ jobs:
           # Portable commands only
           cmake --build build --config Release --verbose
           cmake --build build --config Release --target all_verify_interface_header_sets
-          cmake --install build --config Release --prefix /opt/beman.exemplar
+          sudo cmake --install build --config Release --prefix /opt/beman.exemplar
           ls -R /opt/beman.exemplar
       - name: Test Release
         run: ctest --test-dir build --build-config Release
@@ -131,7 +131,7 @@ jobs:
           # Portable commands only
           cmake --build build --config Debug --verbose
           cmake --build build --config Debug --target all_verify_interface_header_sets
-          cmake --install build --config Debug --prefix /opt/beman.exemplar
+          sudo cmake --install build --config Debug --prefix /opt/beman.exemplar
           ls -R /opt/beman.exemplar
       - name: Test Debug
         run: ctest --test-dir build --build-config Debug

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -58,6 +58,9 @@ jobs:
           - description: "Windows MSVC"
             os: windows-latest
             toolchain: "cmake/msvc-toolchain.cmake"
+          - description: "Macos Clang"
+            os: macos-latest
+            toolchain: "cmake/appleclang-toolchain.cmake"
         cpp_version: [17, 20, 23, 26]
         cmake_args:
           - description: "Default"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -106,6 +106,9 @@ jobs:
         uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
           arch: x64
+      - name: Setup Macos
+        if: startsWith(matrix.platform.os, 'macos')
+        run: sudo chmod -R 777 /opt/
       - name: Print installed softwares
         shell: bash
         run: |
@@ -122,7 +125,7 @@ jobs:
           # Portable commands only
           cmake --build build --config Release --verbose
           cmake --build build --config Release --target all_verify_interface_header_sets
-          sudo cmake --install build --config Release --prefix /opt/beman.exemplar
+          cmake --install build --config Release --prefix /opt/beman.exemplar
           ls -R /opt/beman.exemplar
       - name: Test Release
         run: ctest --test-dir build --build-config Release
@@ -131,7 +134,7 @@ jobs:
           # Portable commands only
           cmake --build build --config Debug --verbose
           cmake --build build --config Debug --target all_verify_interface_header_sets
-          sudo cmake --install build --config Debug --prefix /opt/beman.exemplar
+          cmake --install build --config Debug --prefix /opt/beman.exemplar
           ls -R /opt/beman.exemplar
       - name: Test Debug
         run: ctest --test-dir build --build-config Debug

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -58,7 +58,7 @@ jobs:
           - description: "Windows MSVC"
             os: windows-latest
             toolchain: "cmake/msvc-toolchain.cmake"
-          - description: "Macos Clang"
+          - description: "Macos Appleclang"
             os: macos-latest
             toolchain: "cmake/appleclang-toolchain.cmake"
         cpp_version: [17, 20, 23, 26]


### PR DESCRIPTION
This PR expands current CI to perform build-and-test on appleclang in macos.

macos-gcc, macos-llvm is not included to not bloom the number of jobs too much. It should be clear that the CI system will be able to support running gcc/ llvm on macos.

Closes #22 .