### PR TITLE
Use parallel build in CI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Build Release
         run: |
           # Portable commands only
-          cmake --build build --config Release --verbose
+          cmake --build build --config Release --parallel --verbose
           cmake --build build --config Release --target all_verify_interface_header_sets
           cmake --install build --config Release --prefix /opt/beman.exemplar
           ls -R /opt/beman.exemplar
@@ -139,7 +139,7 @@ jobs:
       - name: Build Debug
         run: |
           # Portable commands only
-          cmake --build build --config Debug --verbose
+          cmake --build build --config Debug --parallel --verbose
           cmake --build build --config Debug --target all_verify_interface_header_sets
           cmake --install build --config Debug --prefix /opt/beman.exemplar
           ls -R /opt/beman.exemplar
@@ -175,14 +175,14 @@ jobs:
       - name: Build Release
         run: |
           # Portable commands only
-          cmake --build build --config Release --verbose
+          cmake --build build --config Release --parallel --verbose
           cmake --build build --config Release --target all_verify_interface_header_sets
           cmake --install build --config Release --prefix /opt/beman.exemplar
           ls -R /opt/beman.exemplar
       - name: Build Debug
         run: |
           # Portable commands only
-          cmake --build build --config Debug --verbose
+          cmake --build build --config Debug --parallel --verbose
           cmake --build build --config Debug --target all_verify_interface_header_sets
           cmake --install build --config Debug --prefix /opt/beman.exemplar
           ls -R /opt/beman.exemplar


### PR DESCRIPTION
The GitHub Actions runner [has 4 cores](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for--private-repositories), parallel build should speed up the build process.

Unfortunately, there's not a portable way to add this in preset, see: [here](https://discourse.cmake.org/t/presets-use-number-of-processors-for-number-of-parallel-jobs/4989).