### PR TITLE
No fail fast on CI tests

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -143,6 +143,7 @@ jobs:
   configuration-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         args:
           - name: "Disable build testing"
@@ -184,6 +185,7 @@ jobs:
   compiler-test:
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         compilers:
           - class: GNU

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   preset-test:
     strategy:
+      fail-fast: false
       matrix:
         presets:
           - preset: "gcc-debug"


### PR DESCRIPTION
Right now, if one of the preset tests or compiler test reported error, the entire preset/ compile test pipeline will be cancelled.

See example for compiler here: https://github.com/bemanproject/lazy/actions/runs/12743334139/job/35513073020
For presets here: 
Presets here: https://github.com/bemanproject/inplace_vector/actions/runs/12960992490

Turning fail-fast off maybe more helpful, as it will make platform specific errors easier to identify.

Before: 
![image](https://github.com/user-attachments/assets/7a16ade0-ae40-4446-9973-9a91e7afe404)

After:
![image](https://github.com/user-attachments/assets/096adfb5-7f3c-4f49-ae7f-9a41d58374b0)

This is already added to beman.lazy, see: https://github.com/bemanproject/lazy/commit/aba368a493945757f8a981304e0285fe3b69e5e1