### PR TITLE
Support BUILD_SHARED_LIBS

### DIFF
--- a/src/beman/exemplar/CMakeLists.txt
+++ b/src/beman/exemplar/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_library(beman.exemplar STATIC)
+add_library(beman.exemplar)
 add_library(beman::exemplar ALIAS beman.exemplar)
 
 target_sources(beman.exemplar PRIVATE identity.cpp)


### PR DESCRIPTION
## Problem

Hardcoding STATIC is unneeded and breaks support for the standard CMake feature `BUILD_SHARED_LIBS`.

## Solution

Remove `STATIC` from the `add_library(exemplar)` statement and allow CMake defaults to provide a default static library build.

## Reference

For `add_library` supporting `BUILD_SHARED_LIBS`:
 https://cmake.org/cmake/help/latest/command/add_library.html

Docs for `BUILD_SHARED_LIBS`, including that `STATIC` is the default for CMake built libraries.
 https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html#variable:BUILD_SHARED_LIBS