### PR TITLE
Fix codespace ASAN stall

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-22.04
+FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
 
 USER vscode
 
 # Install latest cmake
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
 RUN sudo apt-get update && sudo apt-get install -y cmake
 
 # Install pre-commit

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,4 +12,5 @@ RUN sudo apt-get install -y pipx && pipx install pre-commit
 
 # Newer gcc/ llvm is needed to avoid ASAN Stalling
 # See: https://github.com/google/sanitizers/issues/1614
+# Minimal vesion: clang-18.1.3, gcc-13.2
 RUN sudo apt-get install -y gcc-14

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,8 +10,6 @@ RUN sudo apt-get update && sudo apt-get install -y cmake
 # Install pre-commit
 RUN sudo apt-get install -y pipx && pipx install pre-commit
 
-# Avoid ASAN Stalling
+# Newer gcc/ llvm is needed to avoid ASAN Stalling
 # See: https://github.com/google/sanitizers/issues/1614
-# Alternative is to update to above clang-18 and gcc-13.2
-# Maybe crashing codespace???
-RUN sudo sysctl -w vm.mmap_rnd_bits=28
+RUN sudo apt-get install -y gcc-14

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https:
 RUN sudo apt-get update && sudo apt-get install -y cmake
 
 # Install pre-commit
-RUN sudo apt-get install -y python3-pip && pip3 install pre-commit
+RUN sudo apt-get install -y pipx && pipx install pre-commit
 
 # Avoid ASAN Stalling
 # See: https://github.com/google/sanitizers/issues/1614


### PR DESCRIPTION
This fix #102 . Go read #102 for more of a write-up (Thanks nick!).

This PR updates codespace to use gcc-14.

Please test this PR by going to codespace and type `cmake --workflow --preset gcc-debug`, codespace should run the preset without fail/ hang.