### PR TITLE
Support the use of CTest launchers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
+include(CTestUseLaunchers)
 include(FetchContent)
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,6 @@ project(
     VERSION 0.1.0
 )
 
-enable_testing()
-
 # [CMAKE.SKIP_TESTS]
 option(
     BEMAN_EXEMPLAR_BUILD_TESTS
@@ -38,6 +36,7 @@ include(GNUInstallDirs)
 add_subdirectory(src/beman/exemplar)
 
 if(BEMAN_EXEMPLAR_BUILD_TESTS)
+    enable_testing()
     add_subdirectory(tests/beman/exemplar)
 endif()
 


### PR DESCRIPTION
This reverts commit https://github.com/bemanproject/exemplar/commit/a885d77ab03c5e70ca585af9f7ca4efc22bb132c.

The rationale given in the original commit is not convincing.

It assumes that users may be confused when a target called `test` is not unconditionally available.  There are two problems
with that:

1. The recommended approach by CMake is to `include(CTest)`, which internally defines an option called `BUILD_TESTING` and then *conditionally* invokes `enable_testing()` based on this option.  Hence, the fact that the test target is conditionally available is pretty standard.

2. The test target is called `test` for makefile generators only. It has a different name for IDE generators like VS and Xcode. That means `cmake --build build --target test` is not a portable way to execute the test target anyway.

CMake recommends to `include(CTest)` in the top-level CMakeLists.txt.
Including this module has the following side effects:

* It defines an option called `BUILD_TESTING`.
* It includes `CTestUseLaunchers`.
* It invokes `enable_testing()` if `BUILD_TESTING` is ON.
* It searches for version control systems and dynamic analysis checkers and defines a bunch of build targets for CI.

If those additional build targets are not desired, a project may define its own condition on which it invokes `enable_testing()`.

However, `CTestUseLaunchers` should always be included. Otherwise, setting `CTEST_USE_LAUNCHERS` in a CTest script results in the error message:

```
CMake Error: CTEST_USE_LAUNCHERS is enabled, but the RULE_LAUNCH_COMPILE global property is not defined.
Did you forget to include(CTest) in the toplevel CMakeLists.txt ?
```