### PR TITLE
Rewrite README file

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Setup Macos
         if: startsWith(matrix.platform.os, 'macos')
         run: sudo chmod -R 777 /opt/
-      - name: Print installed softwares
+      - name: Print installed software
         shell: bash
         run: |
           echo "Build system:"
@@ -158,7 +158,7 @@ jobs:
         with:
           cmakeVersion: "~3.25.0"
           ninjaVersion: "^1.11.1"
-      - name: Print installed softwares
+      - name: Print installed software
         run: |
           cmake --version
           ninja --version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
     rev: v0.42.0
     hooks:
     - id: markdownlint
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This project officially supports:
 This project supports [GitHub Codespace](https://github.com/features/codespaces)
 via [Development Containers](https://containers.dev/),
 which allows rapid development and instant hacking in your browser.
-We recommand you using GitHub codespace to explore this project as this
+We recommend you using GitHub codespace to explore this project as this
 requires minimal setup.
 
 You can create a codespace for this project by clicking this badge:
@@ -164,7 +164,7 @@ we advice you download CMake directly from [CMake's website](https://cmake.org/d
 or install via the [Kitware apt library](https://apt.kitware.com/).
 
 A [supported compiler](#supported-platforms) should be available from your package manager.
-Alternatively you could use an install script from official compiler venders.
+Alternatively you could use an install script from official compiler vendors.
 
 Here is an example of how to install the latest stable version of clang
 as per [the official LLVM install guide](https://apt.llvm.org/).
@@ -197,7 +197,7 @@ brew install llvm
 
 ### Configure and Build the project using CMake Preset
 
-This project recommands using [CMake Preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
+This project recommends using [CMake Preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
 to configure, build and test the project.
 Appropriate presets for major compilers has been included by default.
 You can use `cmake --list-presets` to see all available presets.
@@ -216,7 +216,7 @@ thus it has as much sanitizers turned on as possible.
 > [!NOTE]
 >
 > The set of sanitizer supports are different across compilers,
-> you can checout the exact set compiler arguments by looking at the toolchain
+> you can checkout the exact set compiler arguments by looking at the toolchain
 > files under the [`cmake`](cmake/) directory.
 
 The `release` presets are designed for use in production environments,
@@ -225,7 +225,7 @@ thus it has the highest optimization turned on (e.g. `O3`).
 ### Configure and Build the project manually
 
 While [CMake Preset](#configure-and-build-the-project-using-cmake-preset) is
-convient,
+convenient,
 you might want to pass extra config/ compiler arguments for configuration.
 
 To configure, build and test the project with extra arguments,
@@ -287,7 +287,7 @@ Enable building examples. Default: ON. Values: { ON, OFF }.
 ## Integrate beman.exemplar into your project
 
 To use `beman.exemplar` in your C++ project,
-you should include relavent headers from `beman.exemplar` in your source files.
+you should include relevant headers from `beman.exemplar` in your source files.
 
 ```c++
 #include <beman/exemplar/identity.hpp>

--- a/README.md
+++ b/README.md
@@ -126,16 +126,6 @@ This project officially supports:
 >
 > These development environments are verified using our CI configuration.
 
-### Install Environment on Ubuntu 24.04
-
-The latest CMake can be installed from [cmake.org](https://cmake.org/download/).
-A supported compiler (listed below) should be available from your package manager.
-
-```bash
-sudo apt update
-sudo apt install gcc-14
-```
-
 ## Development
 
 ### Develop using GitHub Codespace
@@ -156,6 +146,22 @@ GitHub codespaces, please reference [this doc](https://docs.github.com/en/codesp
 > The codespace container may take up to 5 minutes to build and spin-up,
 > this is normal as we need to build a custom docker container to setup
 > an environment appropriate for beman projects.
+
+
+### Develop locally on Ubuntu
+
+Beman projects requires [recent versions of CMake](#build-environment),
+we advice you download CMake directly from [CMake's website](https://cmake.org/download/)
+or install via the [Kitware apt library](https://apt.kitware.com/).
+
+A [supported compiler](#supported-platforms) should be available from your package manager.
+Alternatively you could use an install script from official compiler venders.
+
+Here is an example of how to install the latest stable version of clang
+as per [the official LLVM install guide](https://apt.llvm.org/).
+```bash
+bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+```
 
 ### Configure and Build the project using CMake Preset
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ This project requires minimal **C++17** and **CMake 3.25** to build.
 
 This project pulls [Google Test](https://github.com/google/googletest)
 from GitHub as a development dependency for its testing framework,
-thus requiring an active internet connection to configure,
-you can disable this behavior by setting `BEMAN_EXEMPLAR_BUILD_TESTS` to `OFF`.
+thus requiring an active internet connection to configure.
+You can disable this behavior by setting cmake option
+[`BEMAN_EXEMPLAR_BUILD_TESTS`](#beman_exemplar_build_tests) to `OFF`
+when configuring the project.
 
 However,
 some examples and tests will not be compiled
@@ -221,10 +223,23 @@ ctest --test-dir build
 When configuring the project manually,
 you can pass an array of project specific CMake configs to customize your build.
 
+Project specific options are prefixed with `BEMAN_EXEMPLAR`.
+You can see the list of available options with:
+
+```bash
+cmake -L | grep "BEMAN_EXEMPLAR"
+```
+
 #### `BEMAN_EXEMPLAR_BUILD_TESTS`
 
 Enable building tests and test infrastructure. Default: ON.
 Values: { ON, OFF }.
+
+You can configure the project to have this option turned off via:
+
+```bash
+cmake -B build -S . -DCMAKE_CXX_STANDARD=20 -DBEMAN_EXEMPLAR_BUILD_TESTS=OFF
+```
 
 > [!TIP]
 > Because this project requires Google Tests as part of its development

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ unless provided compiler support **C++20** or ranges capabilities enabled.
 
 This project officially supports:
 
-- GNU GCC Compiler \[version 12-14\]
-- LLVM Clang++ Compiler \[version 17-20\]
-- AppleClang compiler on Mac OS
-- MSVC compiler on Windows
+* GNU GCC Compiler \[version 12-14\]
+* LLVM Clang++ Compiler \[version 17-20\]
+* AppleClang compiler on Mac OS
+* MSVC compiler on Windows
 
 > [!NOTE]
 >
@@ -227,7 +227,7 @@ thus it has the highest optimization turned on (e.g. `O3`).
 
 ### Configure and Build Manually
 
-While [CMake Presets](#configure-and-build-the-project-using-cmake-preset) are
+While [CMake Presets](#configure-and-build-the-project-using-cmake-presets) are
 convenient, you might want to set different configuration or compiler arguments
 than any provided preset supports.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Its direct usage is usually not needed.
 
 ### Usage: default projection in constrained algorithms
 
- The following code snippet illustrates how we can achieve a default projection using `beman::exemplar::identity`:
+The following code snippet illustrates how we can achieve a default projection using `beman::exemplar::identity`:
 
 ```cpp
 #include <beman/exemplar/identity.hpp>
@@ -83,57 +83,38 @@ Full runnable examples can be found in `examples/` (e.g., [./examples/identity_a
 
 ## Building beman.exemplar
 
-### Dependencies
-<!-- TODO Darius: rewrite section!-->
+### Build Environment
 
-This project has no C or C++ dependencies.
+This project requires minimal **C++17** and **CMake 3.25** to build.
 
-Build-time dependencies:
+However,
+some examples and tests will not be compiled
+unless provided compiler support **C++20**.
 
-- `cmake`
-- `ninja`, `make`, or another CMake-supported build system
-  - CMake defaults to "Unix Makefiles" on POSIX systems
+This project pulls [Google Test](https://github.com/google/googletest)
+from GitHub as a development dependency,
+you can disable this behavior by setting `BEMAN_EXEMPLAR_BUILD_TESTS` to `OFF`.
 
-#### How to install dependencies
+#### Install Environment on Ubuntu 24.04
 
-<!-- TODO Darius: rewrite section!-->
+The latest CMake build tool can be installed from [cmake.org](https://cmake.org/download/).
+A supported compiler (listed below) should be available from your package manager.
 
-<details>
-<summary>Dependencies install exemplar on Ubuntu 24.04  </summary>
-
-<!-- TODO Darius: rewrite section!-->
-
-```shell
-# Install tools:
-apt-get install -y cmake make ninja-build
-
-# Toolchains:
-apt-get install                           \
-  g++-14 gcc-14 gcc-13 g++-14             \
-  clang-18 clang++-18 clang-17 clang++-17
+```bash
+sudo apt update
+sudo apt install gcc-14
 ```
 
-</details>
+### Supported Platforms
 
-<details>
-<summary>Dependencies install exemplar on MAC OS $VERSION </summary>
+This project officially support development using:
 
-<!-- TODO Darius: rewrite section!-->
-```shell
-# TODO
-```
+- GNU GCC Compiler version 12+
+- LLVM Clang++ Compiler version 17+
+- AppleClang compiler on Mac OS
+- MSVC compiler on Windows
 
-</details>
-
-<details>
-<summary>Dependencies install exemplar on Windows $VERSION  </summary>
-<!-- TODO Darius: rewrite section!-->
-
-```shell
-# TODO
-```
-
-</details>
+These development environments are varified using our CI system.
 
 ### How to build beman.exemplar
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ This project officially supports:
 This project supports [GitHub Codespace](https://github.com/features/codespaces)
 via [Development Containers](https://containers.dev/),
 which allows rapid development and instant hacking in your browser.
+We recommand you using GitHub codespace to explore this project as this
+requires minimal setup.
 
 You can create a codespace for this project by clicking this badge:
 

--- a/README.md
+++ b/README.md
@@ -81,11 +81,14 @@ int main()
 
 Full runnable examples can be found in [`examples/`](examples/).
 
-## Dependency
+## Dependencies
 
 ### Build Environment
 
-This project requires minimal **C++17** and **CMake 3.25** to build.
+This project requires at least the following to build:
+
+* C++17
+* CMake 3.25
 
 This project pulls [Google Test](https://github.com/google/googletest)
 from GitHub as a development dependency for its testing framework,
@@ -100,8 +103,8 @@ unless provided compiler support **C++20** or ranges capabilities enabled.
 
 > [!TIP]
 >
-> You will be able to see if there's any examples that isn't enabled due to
-> compiler capabilities or minimum C++ version it is configured to in the logs.
+> In the logs you will be able to see if there are any examples that aren't enabled
+> due to compiler capabilities or the configured C++ version.
 >
 > Below is an example:
 >
@@ -178,8 +181,8 @@ bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 <details>
 <summary> For MacOS based systems </summary>
 
-Beman libraries requires [recent versions of CMake](#build-environment),
-you can use `Homebrew` to install the latest major version of CMake.
+Beman libraries require [recent versions of CMake](#build-environment).
+You can use `Homebrew` to install the latest major version of CMake.
 
 ```bash
 brew install cmake
@@ -195,11 +198,11 @@ brew install llvm
 
 </details>
 
-### Configure and Build the project using CMake Preset
+### Configure and Build the Project Using CMake Presets
 
-This project recommends using [CMake Preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
+This project recommends using [CMake Presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
 to configure, build and test the project.
-Appropriate presets for major compilers has been included by default.
+Appropriate presets for major compilers have been included by default.
 You can use `cmake --list-presets` to see all available presets.
 
 Here is an example to invoke the `gcc-debug` preset.
@@ -210,23 +213,23 @@ cmake --workflow --preset gcc-debug
 
 Generally, there's two kinds of presets, `debug` and `release`.
 
-The `debug` presets are designed to aid development,
-thus it has as much sanitizers turned on as possible.
+The `debug` presets are designed to aid development, so it has debugging
+instrumentation enabled and as many sanitizers turned on as possible.
 
 > [!NOTE]
 >
-> The set of sanitizer supports are different across compilers,
-> you can checkout the exact set compiler arguments by looking at the toolchain
+> The set of sanitizer supports are different across compilers.
+> You can checkout the exact set compiler arguments by looking at the toolchain
 > files under the [`cmake`](cmake/) directory.
 
 The `release` presets are designed for use in production environments,
 thus it has the highest optimization turned on (e.g. `O3`).
 
-### Configure and Build the project manually
+### Configure and Build Manually
 
-While [CMake Preset](#configure-and-build-the-project-using-cmake-preset) is
-convenient,
-you might want to pass extra config/ compiler arguments for configuration.
+While [CMake Presets](#configure-and-build-the-project-using-cmake-preset) are
+convenient, you might want to set different configuration or compiler arguments
+than any provided preset supports.
 
 To configure, build and test the project with extra arguments,
 you can run this sets of command.
@@ -287,13 +290,14 @@ Enable building examples. Default: ON. Values: { ON, OFF }.
 ## Integrate beman.exemplar into your project
 
 To use `beman.exemplar` in your C++ project,
-you should include relevant headers from `beman.exemplar` in your source files.
+include an appropriate `beman.exemplar` header from your source code.
 
 ```c++
 #include <beman/exemplar/identity.hpp>
 ```
 
-You will then link your project to `beman.exemplar`.
+How you will link your project against `beman.exemplar` will depend on your build system.
+CMake instructions are provided in following sections.
 
 ### Produce beman.exemplar static library locally
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,12 @@ include an appropriate `beman.exemplar` header from your source code.
 #include <beman/exemplar/identity.hpp>
 ```
 
+> [!NOTE]
+>
+> `beman.exemplar` headers are to be included with the `beman/exemplar/` directories prefixed.
+> It is not supported to alter include search paths to spell the include target another way. For instance,
+> `#include <identity.hpp>` is not a supported interface.
+
 How you will link your project against `beman.exemplar` will depend on your build system.
 CMake instructions are provided in following sections.
 
@@ -336,16 +342,6 @@ any libraries or executables that include beman.exemplar's header file.
 
 ```cmake
 target_link_libraries(yourlib PUBLIC beman::exemplar)
-```
-
-### Linking your project to beman.exemplar with compiler options
-
-Compile your project so that it links to the header and library correctly.
-
-```bash
-c++ -I/opt/beman.exemplar/include \
-    -L/opt/beman.exemplar/lib -lbeman.exemplar \
-    your_project.cpp -o your_project
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Full runnable examples can be found in [`examples/`](examples/).
 
 This project requires minimal **C++17** and **CMake 3.25** to build.
 
+This project pulls [Google Test](https://github.com/google/googletest)
+from GitHub as a development dependency for its testing framework,
+thus requiring an active internet connection to configure,
+you can disable this behavior by setting `BEMAN_EXEMPLAR_BUILD_TESTS` to `OFF`.
+
 However,
 some examples and tests will not be compiled
 unless provided compiler support **C++20**.
@@ -107,10 +112,6 @@ unless provided compiler support **C++20**.
 >
 > Examples to be built: identity_direct_usage
 > ```
-
-This project pulls [Google Test](https://github.com/google/googletest)
-from GitHub as a development dependency for its testing framework,
-you can disable this behavior by setting `BEMAN_EXEMPLAR_BUILD_TESTS` to `OFF`.
 
 #### Install Environment on Ubuntu 24.04
 

--- a/README.md
+++ b/README.md
@@ -346,4 +346,6 @@ c++ -I/opt/beman.exemplar/include \
 
 ## Contributing
 
-Please do! Issues and pull requests are appreciated.
+Please do!
+You encourage you to checkout our [contributor's guide](docs/README.md).
+Issues and pull requests are appreciated.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,49 @@ thus it has as much sanitizers turned on as possible.
 The `release` presets are designed for use in production environments,
 thus it has the highest optimization turned on (e.g. `O3`).
 
+### Configure and Build the project manually
+
+While [CMake Preset](#configure-and-build-the-project-using-cmake-preset) is
+convient,
+you might want to pass extra config/ compiler arguments for configuration.
+
+To configure, build and test the project with no extra arguments,
+you can run this sets of command.
+
+```bash
+cmake -B build -S . -DCMAKE_CXX_STANDARD=20
+cmake --build build
+ctest --test-dir build
+```
+
+> [!IMPORTANT]
+>
+> Beman projects are
+> [passive projects](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#cmake),
+> therefore,
+> you will need to manually specify C++ version via `CMAKE_CXX_STANDARD`
+> when manually configuring the project.
+
+### Project specific configure arguments
+
+When configuring the project manually,
+you can pass an array of project specific CMake configs to customize your build.
+
+#### `BEMAN_EXEMPLAR_BUILD_TESTS`
+
+Enable building tests and test infrastructure. Default: ON.
+Values: { ON, OFF }.
+
+> [!TIP]
+> Because this project requires Google Tests as part of its development
+> dependency,
+> disable building tests avoids the project from pulling Google Tests from
+> GitHub.
+
+#### `BEMAN_EXEMPLAR_BUILD_EXAMPLES`
+
+Enable building examples. Default: ON. Values: { ON, OFF }.
+
 ### Produce a static library
 
 <!--

--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ You can see the list of available options with:
 cmake -LH | grep "BEMAN_EXEMPLAR" -C 2
 ```
 
+<details>
+
+<summary> Details of our CMake configs. </summary>
+
 #### `BEMAN_EXEMPLAR_BUILD_TESTS`
 
 Enable building tests and test infrastructure. Default: ON.
@@ -277,6 +281,8 @@ cmake -B build -S . -DCMAKE_CXX_STANDARD=20 -DBEMAN_EXEMPLAR_BUILD_TESTS=OFF
 #### `BEMAN_EXEMPLAR_BUILD_EXAMPLES`
 
 Enable building examples. Default: ON. Values: { ON, OFF }.
+
+</details>
 
 ### Produce a static library
 

--- a/README.md
+++ b/README.md
@@ -201,11 +201,11 @@ While [CMake Preset](#configure-and-build-the-project-using-cmake-preset) is
 convient,
 you might want to pass extra config/ compiler arguments for configuration.
 
-To configure, build and test the project with no extra arguments,
+To configure, build and test the project with extra arguments,
 you can run this sets of command.
 
 ```bash
-cmake -B build -S . -DCMAKE_CXX_STANDARD=20
+cmake -B build -S . -DCMAKE_CXX_STANDARD=20 # Your extra arguments here.
 cmake --build build
 ctest --test-dir build
 ```

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ This project officially supports:
 
 > [!NOTE]
 >
+> Versions outside of this range would likely work as well,
+> especially if you're using a version above the given range
+> (e.g. HEAD/ nightly).
 > These development environments are verified using our CI configuration.
 
 ## Development
@@ -134,7 +137,7 @@ This project supports [GitHub Codespace](https://github.com/features/codespaces)
 via [Development Containers](https://containers.dev/),
 which allows rapid development and instant hacking in your browser.
 
-You can open create a codespace for this project by clicking this badge:
+You can create a codespace for this project by clicking this badge:
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bemanproject/exemplar)
 
@@ -147,7 +150,6 @@ GitHub codespaces, please reference [this doc](https://docs.github.com/en/codesp
 > this is normal as we need to build a custom docker container to setup
 > an environment appropriate for beman projects.
 
-
 ### Develop locally on Ubuntu
 
 Beman projects requires [recent versions of CMake](#build-environment),
@@ -159,6 +161,7 @@ Alternatively you could use an install script from official compiler venders.
 
 Here is an example of how to install the latest stable version of clang
 as per [the official LLVM install guide](https://apt.llvm.org/).
+
 ```bash
 bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 ```

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Project specific options are prefixed with `BEMAN_EXEMPLAR`.
 You can see the list of available options with:
 
 ```bash
-cmake -L | grep "BEMAN_EXEMPLAR"
+cmake -LH | grep "BEMAN_EXEMPLAR" -C 2
 ```
 
 #### `BEMAN_EXEMPLAR_BUILD_TESTS`

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ int main()
 
 Full runnable examples can be found in [`examples/`](examples/).
 
-## Building beman.exemplar
+## Dependency
 
 ### Build Environment
 
@@ -94,7 +94,7 @@ you can disable this behavior by setting `BEMAN_EXEMPLAR_BUILD_TESTS` to `OFF`.
 
 However,
 some examples and tests will not be compiled
-unless provided compiler support **C++20**.
+unless provided compiler support **C++20** or ranges capabilities enabled.
 
 > [!TIP]
 >
@@ -127,18 +127,70 @@ sudo apt install gcc-14
 
 This project officially supports:
 
-- GNU GCC Compiler version 12+
-- LLVM Clang++ Compiler version 17+
+- GNU GCC Compiler \[version 12-14\]
+- LLVM Clang++ Compiler \[version 17-20\]
 - AppleClang compiler on Mac OS
 - MSVC compiler on Windows
 
-These development environments are verified using our CI configuration.
+> [!NOTE]
+>
+> These development environments are verified using our CI configuration.
 
-### How to build beman.exemplar
+## Development
 
-This project strives to be as normal and simple a CMake project as possible.
-This build workflow in particular will work,
-producing a static `libbeman.exemplar.a` library, ready to package with its headers:
+### Develop using GitHub Codespace
+
+This project supports [GitHub Codespace](https://github.com/features/codespaces)
+via [Development Containers](https://containers.dev/),
+which allows rapid development and instant hacking in your browser.
+
+You can open create a codespace for this project by clicking this badge:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bemanproject/exemplar)
+
+For more detailed documentation regarding creating and developing inside of
+GitHub codespaces, please reference [this doc](https://docs.github.com/en/codespaces/).
+
+> [!NOTE]
+>
+> The codespace container may take up to 5 minutes to build and spin-up,
+> this is normal as we need to build a custom docker container to setup
+> an environment appropriate for beman projects.
+
+### Configure and Build the project using CMake Preset
+
+This project recommands using [CMake Preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
+to configure, build and test the project.
+Appropriate presets for major compilers has been included by default.
+You can use `cmake --list-presets` to see all available presets.
+
+Here is an example to invoke the `gcc-debug` preset.
+
+```shell
+cmake --workflow --preset gcc-debug
+```
+
+Generally, there's two kinds of presets, `debug` and `release`.
+
+The `debug` presets are designed to aid development,
+thus it has as much sanitizers turned on as possible.
+
+> [!NOTE]
+>
+> The set of sanitizer supports are different across compilers,
+> you can checout the exact set compiler arguments by looking at the toolchain
+> files under the [`cmake`](cmake/) directory.
+
+The `release` presets are designed for use in production environments,
+thus it has the highest optimization turned on (e.g. `O3`).
+
+### Produce a static library
+
+<!--
+TODO
+-->
+
+Producing a static `libbeman.exemplar.a` library, ready to package with its headers:
 
 ```shell
 cmake --workflow --preset gcc-debug

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ cmake -LH | grep "BEMAN_EXEMPLAR" -C 2
 
 <details>
 
-<summary> Details of our CMake configs. </summary>
+<summary> Details of CMake arguments. </summary>
 
 #### `BEMAN_EXEMPLAR_BUILD_TESTS`
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 <summary> For MacOS based systems </summary>
 
 Beman libraries require [recent versions of CMake](#build-environment).
-You can use `Homebrew` to install the latest major version of CMake.
+You can use [`Homebrew`](https://brew.sh/) to install the latest major version of CMake.
 
 ```bash
 brew install cmake

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ you can disable this behavior by setting `BEMAN_EXEMPLAR_BUILD_TESTS` to `OFF`.
 
 #### Install Environment on Ubuntu 24.04
 
-The latest CMake build tool can be installed from [cmake.org](https://cmake.org/download/).
+The latest CMake can be installed from [cmake.org](https://cmake.org/download/).
 A supported compiler (listed below) should be available from your package manager.
 
 ```bash
@@ -107,14 +107,14 @@ sudo apt install gcc-14
 
 ### Supported Platforms
 
-This project officially support development using:
+This project officially supports:
 
 - GNU GCC Compiler version 12+
 - LLVM Clang++ Compiler version 17+
 - AppleClang compiler on Mac OS
 - MSVC compiler on Windows
 
-These development environments are varified using our CI system.
+These development environments are verified using our CI configuration.
 
 ### How to build beman.exemplar
 

--- a/README.md
+++ b/README.md
@@ -113,16 +113,6 @@ unless provided compiler support **C++20** or ranges capabilities enabled.
 > Examples to be built: identity_direct_usage
 > ```
 
-#### Install Environment on Ubuntu 24.04
-
-The latest CMake can be installed from [cmake.org](https://cmake.org/download/).
-A supported compiler (listed below) should be available from your package manager.
-
-```bash
-sudo apt update
-sudo apt install gcc-14
-```
-
 ### Supported Platforms
 
 This project officially supports:
@@ -135,6 +125,16 @@ This project officially supports:
 > [!NOTE]
 >
 > These development environments are verified using our CI configuration.
+
+### Install Environment on Ubuntu 24.04
+
+The latest CMake can be installed from [cmake.org](https://cmake.org/download/).
+A supported compiler (listed below) should be available from your package manager.
+
+```bash
+sudo apt update
+sudo apt install gcc-14
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -305,28 +305,6 @@ include an appropriate `beman.exemplar` header from your source code.
 How you will link your project against `beman.exemplar` will depend on your build system.
 CMake instructions are provided in following sections.
 
-### Produce beman.exemplar static library locally
-
-You can include exemplar's headers locally
-by producing a static `libbeman.exemplar.a` library.
-
-```bash
-cmake --workflow --preset gcc-release
-cmake --install build/gcc-release --prefix /opt/beman.exemplar
-```
-
-This will generate such project structure at `/opt/beman.exemplar`.
-
-```txt
-/opt/beman.exemplar
-├── include
-│   └── beman
-│       └── exemplar
-│           └── identity.hpp
-└── lib
-    └── libbeman.exemplar.a
-```
-
 ### Linking your project to beman.exemplar with CMake
 
 For CMake based projects,
@@ -342,6 +320,28 @@ any libraries or executables that include beman.exemplar's header file.
 
 ```cmake
 target_link_libraries(yourlib PUBLIC beman::exemplar)
+```
+
+### Produce beman.exemplar static library locally
+
+You can include exemplar's headers locally
+by producing a static `libbeman.exemplar.a` library.
+
+```bash
+cmake --workflow --preset gcc-release
+cmake --install build/gcc-release --prefix /opt/beman.exemplar
+```
+
+This will generate such directory structure at `/opt/beman.exemplar`.
+
+```txt
+/opt/beman.exemplar
+├── include
+│   └── beman
+│       └── exemplar
+│           └── identity.hpp
+└── lib
+    └── libbeman.exemplar.a
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ int main()
 
 ```
 
-Full runnable examples can be found in `examples/` (e.g., [./examples/identity_as_default_projection.cpp](./examples/identity_as_default_projection.cpp)).
+Full runnable examples can be found in [`examples/`](examples/).
 
 ## Building beman.exemplar
 
@@ -91,8 +91,25 @@ However,
 some examples and tests will not be compiled
 unless provided compiler support **C++20**.
 
+> [!TIP]
+>
+> You will be able to see if there's any examples that isn't enabled due to
+> compiler capabilities or minimum C++ version it is configured to in the logs.
+>
+> Below is an example:
+>
+> ```txt
+> -- Looking for __cpp_lib_ranges
+> -- Looking for __cpp_lib_ranges - not found
+> CMake Warning at examples/CMakeLists.txt:12 (message):
+>   Missing range support! Skip: identity_as_default_projection
+>
+>
+> Examples to be built: identity_direct_usage
+> ```
+
 This project pulls [Google Test](https://github.com/google/googletest)
-from GitHub as a development dependency,
+from GitHub as a development dependency for its testing framework,
 you can disable this behavior by setting `BEMAN_EXEMPLAR_BUILD_TESTS` to `OFF`.
 
 #### Install Environment on Ubuntu 24.04

--- a/README.md
+++ b/README.md
@@ -284,251 +284,65 @@ Enable building examples. Default: ON. Values: { ON, OFF }.
 
 </details>
 
-### Produce a static library
+## Integrate beman.exemplar into your project
 
-<!--
-TODO
--->
+To use `beman.exemplar` in your C++ project,
+you should include relavent headers from `beman.exemplar` in your source files.
 
-Producing a static `libbeman.exemplar.a` library, ready to package with its headers:
+```c++
+#include <beman/exemplar/identity.hpp>
+```
 
-```shell
-cmake --workflow --preset gcc-debug
+You will then link your project to `beman.exemplar`.
+
+### Produce beman.exemplar static library locally
+
+You can include exemplar's headers locally
+by producing a static `libbeman.exemplar.a` library.
+
+```bash
 cmake --workflow --preset gcc-release
 cmake --install build/gcc-release --prefix /opt/beman.exemplar
 ```
 
-<details>
-<summary> Build beman.exemplar (verbose logs) </summary>
+This will generate such project structure at `/opt/beman.exemplar`.
 
-```shell
-# Configure beman.exemplar via gcc-debug workflow for development.
-$ cmake --workflow --preset gcc-debug
-Executing workflow step 1 of 3: configure preset "gcc-debug"
-
-Preset CMake variables:
-
-  CMAKE_BUILD_TYPE="Debug"
-  CMAKE_CXX_COMPILER="g++"
-  CMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=leak -fsanitize=undefined"
-  CMAKE_CXX_STANDARD="20"
-
--- The CXX compiler identification is GNU 11.4.0
--- Detecting CXX compiler ABI info
--- Detecting CXX compiler ABI info - done
--- Check for working CXX compiler: /usr/bin/g++ - skipped
--- Detecting CXX compile features
--- Detecting CXX compile features - done
--- The C compiler identification is GNU 11.4.0
--- Detecting C compiler ABI info
--- Detecting C compiler ABI info - done
--- Check for working C compiler: /usr/bin/cc - skipped
--- Detecting C compile features
--- Detecting C compile features - done
--- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter
--- Performing Test CMAKE_HAVE_LIBC_PTHREAD
--- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
--- Found Threads: TRUE
--- Configuring done
--- Generating done
--- Build files have been written to: /home/runner/work/exemplar/exemplar/build/gcc-debug
-
-Executing workflow step 2 of 3: build preset "gcc-debug"
-
-[1/14] Building CXX object src/beman/exemplar/CMakeFiles/beman.exemplar.dir/identity.cpp.o
-[2/14] Linking CXX static library src/beman/exemplar/libbeman.exemplar.a
-[3/14] Building CXX object examples/CMakeFiles/beman.exemplar.examples.identity_direct_usage.dir/identity_direct_usage.cpp.o
-[4/14] Linking CXX executable examples/beman.exemplar.examples.identity_direct_usage
-[5/14] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
-[6/14] Building CXX object src/beman/exemplar/CMakeFiles/beman.exemplar.tests.dir/identity.t.cpp.o
-[7/14] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.o
-[8/14] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o
-[9/14] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
-[10/14] Linking CXX static library lib/libgtest.a
-[11/14] Linking CXX static library lib/libgtest_main.a
-[12/14] Linking CXX static library lib/libgmock.a
-[13/14] Linking CXX static library lib/libgmock_main.a
-[14/14] Linking CXX executable src/beman/exemplar/beman.exemplar.tests
-
-Executing workflow step 3 of 3: test preset "gcc-debug"
-
-Test project /home/runner/work/exemplar/exemplar/build/gcc-debug
-    Start 1: IdentityTest.call_identity_with_int
-1/4 Test #1: IdentityTest.call_identity_with_int ...........   Passed    0.13 sec
-    Start 2: IdentityTest.call_identity_with_custom_type
-2/4 Test #2: IdentityTest.call_identity_with_custom_type ...   Passed    0.01 sec
-    Start 3: IdentityTest.compare_std_vs_beman
-3/4 Test #3: IdentityTest.compare_std_vs_beman .............   Passed    0.01 sec
-    Start 4: IdentityTest.check_is_transparent
-4/4 Test #4: IdentityTest.check_is_transparent .............   Passed    0.01 sec
-
-100% tests passed, 0 tests failed out of 4
-
-Total Test time (real) =   0.18 sec
-
-# Configure beman.exemplar via gcc-release workflow for direct usage.
-$ cmake --workflow --preset gcc-release
-Executing workflow step 1 of 3: configure preset "gcc-release"
-
-Preset CMake variables:
-
-  CMAKE_BUILD_TYPE="RelWithDebInfo"
-  CMAKE_CXX_COMPILER="g++"
-  CMAKE_CXX_FLAGS="-O3"
-  CMAKE_CXX_STANDARD="20"
-
--- The CXX compiler identification is GNU 11.4.0
--- Detecting CXX compiler ABI info
--- Detecting CXX compiler ABI info - done
--- Check for working CXX compiler: /usr/bin/g++ - skipped
--- Detecting CXX compile features
--- Detecting CXX compile features - done
--- The C compiler identification is GNU 11.4.0
--- Detecting C compiler ABI info
--- Detecting C compiler ABI info - done
--- Check for working C compiler: /usr/bin/cc - skipped
--- Detecting C compile features
--- Detecting C compile features - done
--- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter
--- Performing Test CMAKE_HAVE_LIBC_PTHREAD
--- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
--- Found Threads: TRUE
--- Configuring done
--- Generating done
--- Build files have been written to: /home/runner/work/exemplar/exemplar/build/gcc-release
-
-Executing workflow step 2 of 3: build preset "gcc-release"
-
-[1/14] Building CXX object src/beman/exemplar/CMakeFiles/beman.exemplar.dir/identity.cpp.o
-[2/14] Linking CXX static library src/beman/exemplar/libbeman.exemplar.a
-[3/14] Building CXX object examples/CMakeFiles/beman.exemplar.examples.identity_direct_usage.dir/identity_direct_usage.cpp.o
-[4/14] Linking CXX executable examples/beman.exemplar.examples.identity_direct_usage
-[5/14] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
-[6/14] Building CXX object src/beman/exemplar/CMakeFiles/beman.exemplar.tests.dir/identity.t.cpp.o
-[7/14] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.o
-[8/14] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o
-[9/14] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
-[10/14] Linking CXX static library lib/libgtest.a
-[11/14] Linking CXX static library lib/libgtest_main.a
-[12/14] Linking CXX static library lib/libgmock.a
-[13/14] Linking CXX executable src/beman/exemplar/beman.exemplar.tests
-[14/14] Linking CXX static library lib/libgmock_main.a
-
-Executing workflow step 3 of 3: test preset "gcc-release"
-
-Test project /home/runner/work/exemplar/exemplar/build/gcc-release
-    Start 1: IdentityTest.call_identity_with_int
-1/4 Test #1: IdentityTest.call_identity_with_int ...........   Passed    0.00 sec
-    Start 2: IdentityTest.call_identity_with_custom_type
-2/4 Test #2: IdentityTest.call_identity_with_custom_type ...   Passed    0.00 sec
-    Start 3: IdentityTest.compare_std_vs_beman
-3/4 Test #3: IdentityTest.compare_std_vs_beman .............   Passed    0.00 sec
-    Start 4: IdentityTest.check_is_transparent
-4/4 Test #4: IdentityTest.check_is_transparent .............   Passed    0.00 sec
-
-100% tests passed, 0 tests failed out of 4
-
-Total Test time (real) =   0.01 sec
-
-# Run examples.
-$ build/gcc-release/examples/beman.exemplar.examples.identity_direct_usage
-2024
-
-```
-
-</details>
-
-<details>
-<summary> Install beman.exemplar (verbose logs) </summary>
-
-```shell
-# Install build artifacts from `build` directory into `opt/beman.exemplar` path.
-$ cmake --install build/gcc-release --prefix /opt/beman.exemplar
--- Install configuration: "RelWithDebInfo"
--- Up-to-date: /opt/beman.exemplar/lib/libbeman.exemplar.a
--- Up-to-date: /opt/beman.exemplar/include/beman/exemplar/identity.hpp
-
-
-# Check tree.
-$ tree /opt/beman.exemplar
+```txt
 /opt/beman.exemplar
 ├── include
-│   └── beman
-│       └── exemplar
-│           └── identity.hpp
+│   └── beman
+│       └── exemplar
+│           └── identity.hpp
 └── lib
     └── libbeman.exemplar.a
-
-4 directories, 2 files
 ```
 
-</details>
+### Linking your project to beman.exemplar with CMake
 
-<details>
-<summary> Disable tests build </summary>
-
-To build this project with tests disabled (and their dependencies),
-simply use `BEMAN_EXEMPLAR_BUILD_TESTING=OFF` as documented in upstream [CMake documentation](https://cmake.org/cmake/help/latest/module/CTest.html):
-
-```shell
-cmake -B build -S . -DBEMAN_EXEMPLAR_BUILD_TESTING=OFF
-```
-
-</details>
-
-## Integrate beman.exemplar into your project
-
-<details>
-<summary> Use beman.exemplar directly from C++ </summary>
-<!-- TODO Darius: rewrite section!-->
-
-If you want to use `beman.exemplar` from your project,
-you can include `beman/exemplar/*.hpp`  files from your C++ source files
-
-```cpp
-#include <beman/exemplar/identity.hpp>
-```
-
-and directly link with `libbeman.exemplar.a`
-
-```shell
-# Assume /opt/beman.exemplar staging directory.
-$ c++ -o identity_usage examples/identity_usage.cpp \
-    -I /opt/beman.exemplar/include/ \
-    -L/opt/beman.exemplar/lib/ -lbeman.exemplar
-```
-
-</details>
-
-<details>
-<summary> Use beman.exemplar directly from CMake </summary>
-
-<!-- TODO Darius: rewrite section! Add examples. -->
-
-For CMake based projects, you will need to use the `beman.exemplar` CMake module to define the `beman::exemplar` CMake target:
+For CMake based projects,
+you will need to use the `beman.exemplar` CMake module
+to define the `beman::exemplar` CMake target:
 
 ```cmake
 find_package(beman.exemplar REQUIRED)
 ```
 
-You will also need to add `beman::exemplar`
-to the link libraries of any libraries or executables that include `beman/exemplar/*.hpp` in their source or header file.
+You will also need to add `beman::exemplar` to the link libraries of
+any libraries or executables that include beman.exemplar's header file.
 
 ```cmake
 target_link_libraries(yourlib PUBLIC beman::exemplar)
 ```
 
-</details>
+### Linking your project to beman.exemplar with compiler options
 
-<details>
-<summary> Use beman.exemplar from other build systems </summary>
+Compile your project so that it links to the header and library correctly.
 
-<!-- TODO Darius: rewrite section! Add examples. -->
-
-Build systems that support `pkg-config` by providing a `beman.exemplar.pc` file.
-Build systems that support interoperation via `pkg-config` should be able to detect `beman.exemplar` for you automatically.
-
-</details>
+```bash
+c++ -I/opt/beman.exemplar/include \
+    -L/opt/beman.exemplar/lib -lbeman.exemplar \
+    your_project.cpp -o your_project
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,12 @@ GitHub codespaces, please reference [this doc](https://docs.github.com/en/codesp
 > this is normal as we need to build a custom docker container to setup
 > an environment appropriate for beman projects.
 
-### Develop locally on Ubuntu
+### Develop locally on your machines
 
-Beman projects requires [recent versions of CMake](#build-environment),
+<details>
+<summary> For Linux based systems </summary>
+
+Beman libraries requires [recent versions of CMake](#build-environment),
 we advice you download CMake directly from [CMake's website](https://cmake.org/download/)
 or install via the [Kitware apt library](https://apt.kitware.com/).
 
@@ -167,6 +170,28 @@ as per [the official LLVM install guide](https://apt.llvm.org/).
 ```bash
 bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 ```
+
+</details>
+
+<details>
+<summary> For MacOS based systems </summary>
+
+Beman libraries requires [recent versions of CMake](#build-environment),
+you can use `Homebrew` to install the latest major version of CMake.
+
+```bash
+brew install cmake
+```
+
+A [supported compiler](#supported-platforms) is also available from brew.
+
+For example, you can install latest major release of Clang++ compiler as:
+
+```bash
+brew install llvm
+```
+
+</details>
 
 ### Configure and Build the project using CMake Preset
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ ctest --test-dir build
 > Beman projects are
 > [passive projects](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#cmake),
 > therefore,
-> you will need to manually specify C++ version via `CMAKE_CXX_STANDARD`
+> you will need to specify C++ version via `CMAKE_CXX_STANDARD`
 > when manually configuring the project.
 
 ### Project specific configure arguments


### PR DESCRIPTION
Fix #97 .

Please squash merge.

Major painpoints in current README:
- Current README is full of TODOs
- Not all of our developer tools have been documented (`pre-commit`, CMake preset, `codespace`)
- A lot of replacement needed to bootstrap a new project

This PR aim to fix these issues.

Major TODOs
- [x] Address all current TODOs, mostly left out explicitly to @neatudarius 
- [x] Define minimal C++ version
- [x] Define minimal CMake version
- [x] Define tested range of compiler support
- [x] Document that cmake config requires internet access due to testing
- [x] Document CMake config flags: Disable Tests
- [x] Document CMake config flags: Disable examples
- [x] Document codespace support as rapid development
- [x] Document CMake preset as one-line configuration
- [ ] ~~Document developer facing tool: `pre-commit`~~
- [ ] ~~Document developer facing tool: Current GitHub Action workflow and how to update them.~~

Developer facing tool would be moved to `docs/`, see #120 .

This PR also adds spell checks.