### PR TITLE
Make project header only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,7 @@
 
 cmake_minimum_required(VERSION 3.25)
 
-project(
-    beman.exemplar # CMake Project Name, which is also the name of the top-level
-    # targets (e.g., library, executable, etc.).
-    DESCRIPTION "A Beman library exemplar"
-    LANGUAGES CXX
-)
+project(beman.exemplar DESCRIPTION "A Beman library exemplar" LANGUAGES CXX)
 
 enable_testing()
 
@@ -41,7 +36,7 @@ if(BEMAN_EXEMPLAR_BUILD_TESTS)
     FetchContent_MakeAvailable(googletest)
 endif()
 
-add_subdirectory(src/beman/exemplar)
+add_subdirectory(include/beman/exemplar)
 
 if(BEMAN_EXEMPLAR_BUILD_TESTS)
     add_subdirectory(tests/beman/exemplar)

--- a/include/beman/exemplar/CMakeLists.txt
+++ b/include/beman/exemplar/CMakeLists.txt
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_library(beman.exemplar)
+add_library(beman.exemplar INTERFACE)
 add_library(beman::exemplar ALIAS beman.exemplar)
-
-target_sources(beman.exemplar PRIVATE identity.cpp)
 
 target_sources(
     beman.exemplar

--- a/src/beman/exemplar/identity.cpp
+++ b/src/beman/exemplar/identity.cpp
@@ -1,3 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-#include <beman/exemplar/identity.hpp>


### PR DESCRIPTION
From usage experience, subsequent project usually only put source code in `include` directory and not touch the `src/` folder.

Having current `src/` folder increase setup friction, as there's an extra empty `src/beman/{NAME}/{NAME}.cpp` file that needs to be updated when adopting as subsequent library, and users doesn't realize there's another CMake file under the folder.

I don't think we should endorse header only library, but I think this is the common case.

This does conflict with #104 , @bretbrownjr 