### PR TITLE
Add skeletons for dev-docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# A guide to contribute/ Develop for Beman Project
+
+TODO: Currently only a skeleton.
+
+## Infrastructure
+
+### Lint

--- a/docs/using_exemplar.md
+++ b/docs/using_exemplar.md
@@ -1,0 +1,6 @@
+# Using Exemplar
+
+This document provides a step-by-step guide to creating your own beman
+library based on [beman.exemplar](https://github.com/bemanproject/exemplar/).
+
+TODO: Currently a skeleton.


### PR DESCRIPTION
This PR adds a skeleton documentation to `docs`.

This is so if anyone has suggestion for documenting something, they can simply create a PR to edit these files. There's a lot of suggestions for docs in our discourse, but they aren't getting collected.

Example use case: https://discourse.bemanproject.org/t/test-infrastructure-preferably-not-google-test/150/18?u=river

I will populate the docs later.