### PR TITLE
Add Test for Basic CMake Config-File Package

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -150,6 +150,8 @@ jobs:
             arg: "-DBEMAN_EXEMPLAR_BUILD_TESTS=OFF"
           - name: "Disable example building"
             arg: "-DBEMAN_EXEMPLAR_BUILD_EXAMPLES=OFF"
+          - name: "Disable config-file package creation"
+            arg: "-DBEMAN_EXEMPLAR_INSTALL_CONFIG_FILE_PACKAGE=OFF"
     name: "CMake: ${{ matrix.args.name }}"
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,10 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
-option(BEMAN_EXEMPLAR_INSTALL_CONFIG_FILE_PACKAGE
-  "Enable creating and installing a CMake config-file package. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
-  ${PROJECT_IS_TOP_LEVEL}
+option(
+    BEMAN_EXEMPLAR_INSTALL_CONFIG_FILE_PACKAGE
+    "Enable creating and installing a CMake config-file package. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
 )
 
 include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(
     # targets (e.g., library, executable, etc.).
     DESCRIPTION "A Beman library exemplar"
     LANGUAGES CXX
+    VERSION 0.1.0
 )
 
 enable_testing()
@@ -23,6 +24,11 @@ option(
     BEMAN_EXEMPLAR_BUILD_EXAMPLES
     "Enable building examples. Default: ON. Values: { ON, OFF }."
     ${PROJECT_IS_TOP_LEVEL}
+)
+
+option(BEMAN_EXEMPLAR_INSTALL_CONFIG_FILE_PACKAGE
+  "Enable creating and installing a CMake config-file package. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+  ${PROJECT_IS_TOP_LEVEL}
 )
 
 include(FetchContent)

--- a/cmake/beman.exemplar-config.cmake.in
+++ b/cmake/beman.exemplar-config.cmake.in
@@ -1,0 +1,7 @@
+set(BEMAN_EXEMPLAR_VERSION @PROJECT_VERSION@)
+
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
+
+check_required_components(@PROJECT_NAME@)

--- a/src/beman/exemplar/CMakeLists.txt
+++ b/src/beman/exemplar/CMakeLists.txt
@@ -13,13 +13,36 @@ target_sources(
         FILES ${PROJECT_SOURCE_DIR}/include/beman/exemplar/identity.hpp
 )
 
-set_target_properties(beman.exemplar PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
+set_target_properties(beman.exemplar PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON EXPORT_NAME exemplar)
 
 install(
     TARGETS beman.exemplar
     EXPORT beman.exemplar
     DESTINATION
-    $<$<CONFIG:Debug>:debug/>${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION $<$<CONFIG:Debug>:debug/>${CMAKE_INSTALL_BINDIR}
+    ${CMAKE_INSTALL_LIBDIR}$<$<CONFIG:Debug>:/debug>
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}$<$<CONFIG:Debug>:/debug>
     FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+if(BEMAN_EXEMPLAR_INSTALL_CONFIG_FILE_PACKAGE)
+  include(CMakePackageConfigHelpers)
+
+  configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in" "${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    PATH_VARS PROJECT_NAME PROJECT_VERSION
+  )
+
+  write_basic_package_version_file("${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+  )
+
+  install(FILES
+    "${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
+    "${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    COMPONENT development
+  )
+
+  install(EXPORT beman.exemplar DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" NAMESPACE beman FILE ${PROJECT_NAME}-targets.cmake COMPONENT development)
+endif()

--- a/src/beman/exemplar/CMakeLists.txt
+++ b/src/beman/exemplar/CMakeLists.txt
@@ -13,7 +13,10 @@ target_sources(
         FILES ${PROJECT_SOURCE_DIR}/include/beman/exemplar/identity.hpp
 )
 
-set_target_properties(beman.exemplar PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON EXPORT_NAME exemplar)
+set_target_properties(
+    beman.exemplar
+    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON EXPORT_NAME exemplar
+)
 
 install(
     TARGETS beman.exemplar
@@ -25,24 +28,34 @@ install(
 )
 
 if(BEMAN_EXEMPLAR_INSTALL_CONFIG_FILE_PACKAGE)
-  include(CMakePackageConfigHelpers)
+    include(CMakePackageConfigHelpers)
 
-  configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in" "${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
-    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
-    PATH_VARS PROJECT_NAME PROJECT_VERSION
-  )
+    configure_package_config_file(
+        "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in"
+        "${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
+        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+        PATH_VARS PROJECT_NAME PROJECT_VERSION
+    )
 
-  write_basic_package_version_file("${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-  )
+    write_basic_package_version_file(
+        "${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-version.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
 
-  install(FILES
-    "${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
-    "${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
-    COMPONENT development
-  )
+    install(
+        FILES
+            "${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
+            "${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-version.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+        COMPONENT development
+    )
 
-  install(EXPORT beman.exemplar DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" NAMESPACE beman:: FILE ${PROJECT_NAME}-targets.cmake COMPONENT development)
+    install(
+        EXPORT beman.exemplar
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+        NAMESPACE beman::
+        FILE ${PROJECT_NAME}-targets.cmake
+        COMPONENT development
+    )
 endif()

--- a/src/beman/exemplar/CMakeLists.txt
+++ b/src/beman/exemplar/CMakeLists.txt
@@ -44,5 +44,5 @@ if(BEMAN_EXEMPLAR_INSTALL_CONFIG_FILE_PACKAGE)
     COMPONENT development
   )
 
-  install(EXPORT beman.exemplar DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" NAMESPACE beman FILE ${PROJECT_NAME}-targets.cmake COMPONENT development)
+  install(EXPORT beman.exemplar DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" NAMESPACE beman:: FILE ${PROJECT_NAME}-targets.cmake COMPONENT development)
 endif()


### PR DESCRIPTION
This PR extends #121 to include a test to verify that the CMake config-file package is valid. That is:

- The config-file package can be used with the command `find_package(beman.exemplar REQUIRED)`.
- The config-file package correctly exports the `beman::exemplar` target.
- The exported `beman::exemplar` target can be linked.

The directory layout I chose is somewhat arbitrary, so please let me know if we should move some of the files to different directories.

Alternatively, if this is not how we want to integrate config-file package tests, please let me know.