### PR TITLE
bump gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,14 +31,14 @@ include(GNUInstallDirs)
 if(BEMAN_EXEMPLAR_BUILD_TESTS)
     # Fetch GoogleTest
     FetchContent_Declare(
-        googletest
+        GTest
         GIT_REPOSITORY https://github.com/google/googletest.git
         GIT_TAG
-            f8d7d77c06936315286eb55f8de22cd23c188571 # release-1.14.0
+            6910c9d9165801d8827d628cb72eb7ea9dd538c5 # release-1.16.0
         EXCLUDE_FROM_ALL
     )
     set(INSTALL_GTEST OFF) # Disable GoogleTest installation
-    FetchContent_MakeAvailable(googletest)
+    FetchContent_MakeAvailable(GTest)
 endif()
 
 add_subdirectory(src/beman/exemplar)


### PR DESCRIPTION
Bump release to 1.16.0 and use GTest as the package name.
    
This should fix the issues found in https://github.com/bemanproject/exemplar/pull/92