### PR TITLE
Fix typo in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,5 +12,5 @@ RUN sudo apt-get install -y pipx && pipx install pre-commit
 
 # Newer gcc/ llvm is needed to avoid ASAN Stalling
 # See: https://github.com/google/sanitizers/issues/1614
-# Minimal vesion: clang-18.1.3, gcc-13.2
+# Minimal version: clang-18.1.3, gcc-13.2
 RUN sudo apt-get install -y gcc-14


### PR DESCRIPTION
Fix typo "vesion" in Dockerfile caught by spell checker introduced in #111 .

Should resolve the CI on the main branch.

See spell checker output here: 
https://github.com/bemanproject/exemplar/actions/runs/13593334160/job/38004472117