### PR TITLE
Support vcpkg dependencies

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "0ca64b4e1c70fa6d9f53b369b8f3f0843797c20c",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": [
+    "gtest"
+  ]
+}


### PR DESCRIPTION
* Add a `vcpkg.json` configuration to enumerate a GoogleTest logical dependency in `vcpkg.json`
* Add a `vcpkg-configuration.json` to select a known-good release of vcpkg dependencies for consistent reproduction of builds. This is effectively a lockfile in the form of a vcpkg commit SHA.

This will provide consistent, cross-platform development workflows when using vcpkg for managing dependencies (i.e., GoogleTest). This is an intermediate step towards #135, but this change does not fully package this project for vcpkg. That would require authoring a "portfile", either in this repo or (my preference) in the upstream vcpkg repo.

I'm going to leave this as a Draft until the following is true of this PR:

* [ ] Wire up the newly supported workflow to CI. CI should fail if vcpkg JSON files are missing, empty, or otherwise not meeting requirements. This could provide a consistent vcpkg-based CI on all supported OSs if that's attractive.

* [ ] Add documentation demonstrating the support for building against vcpkg dependencies.