### PR TITLE
Improve the Fetch gtest workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,22 @@ ctest --test-dir build
 > you will need to specify C++ version via `CMAKE_CXX_STANDARD`
 > when manually configuring the project.
 
+###  Finding and Fetching GTest from GitHub
+If you do not have GoogleTest installed on your development system, you may
+optionally configure this project to download a known-compatible release of
+GoogleTest from source and build it as well.
+
+Example commands:
+```shell
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=./cmake/gnu-toolchain.cmake -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=./cmake/use-fetch-content.cmake -DCMAKE_CXX_STANDARD=20
+cmake --build build --target all
+cmake --build build --target test
+```
+
+The precise version of GoogleTest that will be used is maintained in
+`./lockfile.json`.
+
+
 ### Project specific configure arguments
 
 When configuring the project manually,
@@ -292,22 +308,6 @@ cmake -B build -S . -DCMAKE_CXX_STANDARD=20 -DBEMAN_EXEMPLAR_BUILD_TESTS=OFF
 #### `BEMAN_EXEMPLAR_BUILD_EXAMPLES`
 
 Enable building examples. Default: ON. Values: { ON, OFF }.
-
-</details>
-
-<details>
-<summary> Build GoogleTest dependency from github.com </summary>
-
-If you do not have GoogleTest installed on your development system, you may
-optionally configure this project to download a known-compatible release of
-GoogleTest from source and build it as well.
-
-```shell
-cmake -B build -S . -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=./cmake/use-fetch-content.cmake
-```
-
-The precise version of GoogleTest that will be used is maintained in
-`./lockfile.json`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ Example commands:
 
 ```shell
 cmake -B build -S . \
-    -DCMAKE_TOOLCHAIN_FILE=./cmake/gnu-toolchain.cmake \
     -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=./cmake/use-fetch-content.cmake \
     -DCMAKE_CXX_STANDARD=20
 cmake --build build --target all

--- a/README.md
+++ b/README.md
@@ -256,21 +256,25 @@ ctest --test-dir build
 > you will need to specify C++ version via `CMAKE_CXX_STANDARD`
 > when manually configuring the project.
 
-###  Finding and Fetching GTest from GitHub
+### Finding and Fetching GTest from GitHub
+
 If you do not have GoogleTest installed on your development system, you may
 optionally configure this project to download a known-compatible release of
 GoogleTest from source and build it as well.
 
 Example commands:
+
 ```shell
-cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=./cmake/gnu-toolchain.cmake -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=./cmake/use-fetch-content.cmake -DCMAKE_CXX_STANDARD=20
+cmake -B build -S . \
+    -DCMAKE_TOOLCHAIN_FILE=./cmake/gnu-toolchain.cmake \
+    -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=./cmake/use-fetch-content.cmake \
+    -DCMAKE_CXX_STANDARD=20
 cmake --build build --target all
 cmake --build build --target test
 ```
 
 The precise version of GoogleTest that will be used is maintained in
 `./lockfile.json`.
-
 
 ### Project specific configure arguments
 

--- a/cmake/use-fetch-content.cmake
+++ b/cmake/use-fetch-content.cmake
@@ -165,8 +165,6 @@ function(BemanExemplar_provideDependency method package_name)
             endif()
         endif()
     endforeach()
-
-    set(GTest_FOUND TRUE PARENT_SCOPE)
 endfunction()
 
 cmake_language(


### PR DESCRIPTION
Pull the documentation of how to fetch GTest from github out of the details block and higher into the docs. This is will be a common workflow and should be easier to find. 

Also fix a nit in the cmake module where GTest_FOUND is set for any package that is pulled in via the module. 