### PR TITLE
Fix typo in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -56,7 +56,7 @@ Explain how is this tested.
 <!--
 The convention in Beman is for the PR author to merge the PR once it's ready.
 You can check this box to indicate that you would like Beman members to merge the PR
-for you when appropropriate reviews have passed.
+for you when appropriate reviews have passed.
 
 Please note that:
 1. Stale PR may still be merged by a Beman member,


### PR DESCRIPTION
<!--
Please follow our code of conduct when engaging in the Beman community:
https://github.com/bemanproject/beman/blob/main/docs/CODE_OF_CONDUCT.md
-->

<!--
Thank you for your contribution!

If you are updating project structure or build configs:
- Make sure your contribution conforms to the Beman Standard:
  https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md
- For new CMake arguments / presets: please make sure you added appropriate CI tests.

If you are updating documentation:
- Make sure badges and pictures does not impact readability.

If you are updating implementations:
- Make sure you submit appropriate testing.

We encourage small and incremental additions instead of large redesigns.
They are easier and faster to review.
They are also less likely to introduce bugs.

While we do not formally adopt this guide as a standard,
we encourage you to read and consider:
"The CL author’s guide to getting through code review".
https://google.github.io/eng-practices/review/developer/

Regardless, feel free to open a PR on your existing changes.
We appreciate the suggestion and will help out.

Please run pre-commit against your change to comply with our linting rules.
The command to check all files in the directory is:
$ pre-commit run --all-files
-->

<!-- markdownlint-disable-next-line MD041 -->
## Description

This PR fixes a typo in the current PR template, which is breaking current CI check on main.

## Motivation and Context

Current lint check on main is breaking due to this typo.

## Testing

I have manually ran:

```
⋊> ~/b/exemplar on pr-typo ◦ pre-commit run --color=always --all-files
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check for added large files..............................................Passed
clang-format.............................................................Passed
CMake linting............................................................Passed
markdownlint.............................................................Passed
codespell................................................................Passed
```

## Meta

<!--
The convention in Beman is for the PR author to merge the PR once it's ready.
You can check this box to indicate that you would like Beman members to merge the PR
for you when appropropriate reviews have passed.

Please note that:
1. Stale PR may still be merged by a Beman member,
if you need significant time to work on your PR,
leave a comment and change it's status to draft.
2. If you are not a member of the Beman project,
you may not have the permission necessary to merge your own PR.
-->

- [x] If all approvals are obtained and the PR is green, any Beman member can merge the PR.

<!-- make sure you run pre-commit before opening a PR -->
