### PR TITLE
CMake workflows build in parallel by default

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -116,36 +116,65 @@
   ],
   "buildPresets": [
     {
+      "name": "_root-build",
+      "hidden": true,
+      "jobs": 0
+    },
+    {
       "name": "gcc-debug",
-      "configurePreset": "gcc-debug"
+      "configurePreset": "gcc-debug",
+      "inherits": [
+        "_root-build"
+      ]
     },
     {
       "name": "gcc-release",
-      "configurePreset": "gcc-release"
+      "configurePreset": "gcc-release",
+      "inherits": [
+        "_root-build"
+      ]
     },
     {
       "name": "llvm-debug",
-      "configurePreset": "llvm-debug"
+      "configurePreset": "llvm-debug",
+      "inherits": [
+        "_root-build"
+      ]
     },
     {
       "name": "llvm-release",
-      "configurePreset": "llvm-release"
+      "configurePreset": "llvm-release",
+      "inherits": [
+        "_root-build"
+      ]
     },
     {
       "name": "appleclang-debug",
-      "configurePreset": "appleclang-debug"
+      "configurePreset": "appleclang-debug",
+      "inherits": [
+        "_root-build"
+      ]
     },
     {
       "name": "appleclang-release",
-      "configurePreset": "appleclang-release"
+      "configurePreset": "appleclang-release",
+      "inherits": [
+        "_root-build"
+      ]
     },
     {
       "name": "msvc-debug",
-      "configurePreset": "msvc-debug"
+      "configurePreset": "msvc-debug",
+      "inherits": [
+        "_root-build"
+      ]
     },
     {
       "name": "msvc-release",
-      "configurePreset": "msvc-release"
+      "configurePreset": "msvc-release",
+      "inherits": [
+        "_root-build"
+      ]
     }
   ],
   "testPresets": [


### PR DESCRIPTION
Setting `"jobs": 0` will make CMake use the native build tool's default number of concurrent processes, which is equal to `$(nproc)` for ninja.
