### PR TITLE
CMake: Add -fsanitize-undefined-trap-on-error to MaxSan configuration

### DIFF
--- a/cmake/gnu-toolchain.cmake
+++ b/cmake/gnu-toolchain.cmake
@@ -20,7 +20,7 @@ set(CMAKE_CXX_COMPILER g++)
 
 if(BEMAN_BUILDSYS_SANITIZER STREQUAL "MaxSan")
     set(SANITIZER_FLAGS
-        "-fsanitize=address -fsanitize=leak -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=undefined"
+        "-fsanitize=address -fsanitize=leak -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=undefined -fsanitize-undefined-trap-on-error"
     )
 elseif(BEMAN_BUILDSYS_SANITIZER STREQUAL "TSan")
     set(SANITIZER_FLAGS "-fsanitize=thread")

--- a/cmake/llvm-toolchain.cmake
+++ b/cmake/llvm-toolchain.cmake
@@ -20,7 +20,7 @@ set(CMAKE_CXX_COMPILER clang++)
 
 if(BEMAN_BUILDSYS_SANITIZER STREQUAL "MaxSan")
     set(SANITIZER_FLAGS
-        "-fsanitize=address -fsanitize=leak -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=undefined"
+        "-fsanitize=address -fsanitize=leak -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=undefined -fsanitize-undefined-trap-on-error"
     )
 elseif(BEMAN_BUILDSYS_SANITIZER STREQUAL "TSan")
     set(SANITIZER_FLAGS "-fsanitize=thread")


### PR DESCRIPTION
Previously, the following implementation of identity would pass all tests under MaxSan:

```
struct identity {
    // Returns `t`.
    template <class T>
    constexpr T&& operator()(T&& t) const noexcept {
        int x = std::numeric_limits<int>::max();
        ++x;
        return std::forward<T>(t);
    }

    using is_transparent = __is_transparent;
};
```

This is because UndefinedBehaviorSanitizer would diagnose the integer overflow by printing, but would not abort the program:

```
[ RUN      ] IdentityTest.check_is_transparent
bemanproject/exemplar/include/beman/exemplar/identity.hpp:37:7: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
[       OK ] IdentityTest.check_is_transparent (0 ms)
```

After this change, the test correctly fails, with SIGILL:

```
The following tests FAILED:
          1 - IdentityTest.call_identity_with_int (ILLEGAL)
```
