### PR TITLE
Add Windows subsection under local development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,26 @@ brew install llvm
 
 </details>
 
+<details>
+<summary> For Windows </summary>
+
+To build Beman libraries, you will need the MSVC compiler. MSVC can be obtained
+by installing Visual Studio; the free Visual Studio 2022 Community Edition can
+be downloaded from
+[Microsoft](https://visualstudio.microsoft.com/vs/community/).
+
+After Visual Studio has been installed, you can launch "Developer PowerShell for
+VS 2022" by typing it into Windows search bar. This shell environment will
+provide CMake, Ninja, and MSVC, allowing you to build the library and run the
+tests.
+
+Note that you will need to use FetchContent to build GoogleTest. To do so,
+please see the instructions in the "Build GoogleTest dependency from github.com"
+dropdown in the [Project specific configure
+arguments](#project-specific-configure-arguments) section.
+
+</details>
+
 ### Configure and Build the Project Using CMake Presets
 
 This project recommends using [CMake Presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
@@ -303,7 +323,7 @@ optionally configure this project to download a known-compatible release of
 GoogleTest from source and build it as well.
 
 ```shell
-cmake -B build -S . -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=./cmake/use-fetch-content.cmake
+cmake -B build -S . -DCMAKE_CXX_STANDARD=20 -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="./cmake/use-fetch-content.cmake"
 ```
 
 The precise version of GoogleTest that will be used is maintained in


### PR DESCRIPTION
This provides instructions for installing and using Visual Studio, and modifies the example command under "Build GoogleTest dependency from github.com" to a version that properly configures the project out of the box in PowerShell for VS 2022.