### PR TITLE
beman.exemplar => beman-exemplar

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -142,8 +142,8 @@ jobs:
           # Portable commands only
           cmake --build build --config Release --parallel --verbose
           cmake --build build --config Release --target all_verify_interface_header_sets
-          cmake --install build --config Release --prefix /opt/beman.exemplar
-          ls -R /opt/beman.exemplar
+          cmake --install build --config Release --prefix /opt/beman-exemplar
+          ls -R /opt/beman-exemplar
       - name: Test Release
         run: ctest --test-dir build --build-config Release
       - name: Build Debug
@@ -151,8 +151,8 @@ jobs:
           # Portable commands only
           cmake --build build --config Debug --parallel --verbose
           cmake --build build --config Debug --target all_verify_interface_header_sets
-          cmake --install build --config Debug --prefix /opt/beman.exemplar
-          ls -R /opt/beman.exemplar
+          cmake --install build --config Debug --prefix /opt/beman-exemplar
+          ls -R /opt/beman-exemplar
       - name: Test Debug
         run: ctest --test-dir build --build-config Debug
 
@@ -195,15 +195,15 @@ jobs:
           # Portable commands only
           cmake --build build --config Release --parallel --verbose
           cmake --build build --config Release --target all_verify_interface_header_sets
-          cmake --install build --config Release --prefix /opt/beman.exemplar
-          ls -R /opt/beman.exemplar
+          cmake --install build --config Release --prefix /opt/beman-exemplar
+          ls -R /opt/beman-exemplar
       - name: Build Debug
         run: |
           # Portable commands only
           cmake --build build --config Debug --parallel --verbose
           cmake --build build --config Debug --target all_verify_interface_header_sets
-          cmake --install build --config Debug --prefix /opt/beman.exemplar
-          ls -R /opt/beman.exemplar
+          cmake --install build --config Debug --prefix /opt/beman-exemplar
+          ls -R /opt/beman-exemplar
 
   compiler-test:
     runs-on: ubuntu-24.04
@@ -277,8 +277,8 @@ jobs:
         run: |
           cmake --build build --config Debug --verbose
           cmake --build build --config Debug --target all_verify_interface_header_sets
-          cmake --install build --config Debug --prefix /opt/beman.exemplar
-          find /opt/beman.exemplar -type f
+          cmake --install build --config Debug --prefix /opt/beman-exemplar
+          find /opt/beman-exemplar -type f
       - name: Test Debug
         run: ctest --test-dir build --build-config Debug
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 project(
-    beman.exemplar # CMake Project Name, which is also the name of the top-level
+    beman-exemplar # CMake Project Name, which is also the name of the top-level
     # targets (e.g., library, executable, etc.).
     DESCRIPTION "A Beman library exemplar"
     LANGUAGES CXX

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# beman.exemplar: A Beman Library Exemplar
+# beman-exemplar: A Beman Library Exemplar
 
 <!--
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
-`beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md).
+`beman-exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md).
 This can be used as a template for those intending to write Beman libraries.
 It may also find use as a minimal and modern  C++ project structure.
 
@@ -331,10 +331,10 @@ The precise version of GoogleTest that will be used is maintained in
 
 </details>
 
-## Integrate beman.exemplar into your project
+## Integrate beman-exemplar into your project
 
-To use `beman.exemplar` in your C++ project,
-include an appropriate `beman.exemplar` header from your source code.
+To use `beman-exemplar` in your C++ project,
+include an appropriate `beman-exemplar` header from your source code.
 
 ```c++
 #include <beman/exemplar/identity.hpp>
@@ -342,50 +342,50 @@ include an appropriate `beman.exemplar` header from your source code.
 
 > [!NOTE]
 >
-> `beman.exemplar` headers are to be included with the `beman/exemplar/` directories prefixed.
+> `beman-exemplar` headers are to be included with the `beman/exemplar/` directories prefixed.
 > It is not supported to alter include search paths to spell the include target another way. For instance,
 > `#include <identity.hpp>` is not a supported interface.
 
-How you will link your project against `beman.exemplar` will depend on your build system.
+How you will link your project against `beman-exemplar` will depend on your build system.
 CMake instructions are provided in following sections.
 
-### Linking your project to beman.exemplar with CMake
+### Linking your project to beman-exemplar with CMake
 
 For CMake based projects,
-you will need to use the `beman.exemplar` CMake module
+you will need to use the `beman-exemplar` CMake module
 to define the `beman::exemplar` CMake target:
 
 ```cmake
-find_package(beman.exemplar REQUIRED)
+find_package(beman-exemplar REQUIRED)
 ```
 
 You will also need to add `beman::exemplar` to the link libraries of
-any libraries or executables that include beman.exemplar's header file.
+any libraries or executables that include beman-exemplar's header file.
 
 ```cmake
 target_link_libraries(yourlib PUBLIC beman::exemplar)
 ```
 
-### Produce beman.exemplar static library locally
+### Produce beman-exemplar static library locally
 
 You can include exemplar's headers locally
-by producing a static `libbeman.exemplar.a` library.
+by producing a static `libbeman-exemplar.a` library.
 
 ```bash
 cmake --workflow --preset gcc-release
-cmake --install build/gcc-release --prefix /opt/beman.exemplar
+cmake --install build/gcc-release --prefix /opt/beman-exemplar
 ```
 
-This will generate such directory structure at `/opt/beman.exemplar`.
+This will generate such directory structure at `/opt/beman-exemplar`.
 
 ```txt
-/opt/beman.exemplar
+/opt/beman-exemplar
 ├── include
 │   └── beman
 │       └── exemplar
 │           └── identity.hpp
 └── lib
-    └── libbeman.exemplar.a
+    └── libbeman-exemplar.a
 ```
 
 ## Contributing

--- a/docs/using_exemplar.md
+++ b/docs/using_exemplar.md
@@ -1,6 +1,6 @@
 # Using Exemplar
 
 This document provides a step-by-step guide to creating your own beman
-library based on [beman.exemplar](https://github.com/bemanproject/exemplar/).
+library based on [beman-exemplar](https://github.com/bemanproject/exemplar/).
 
 TODO: Currently a skeleton.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,10 +18,10 @@ endif()
 message("Examples to be built: ${ALL_EXAMPLES}")
 
 foreach(example ${ALL_EXAMPLES})
-    add_executable(beman.exemplar.examples.${example})
-    target_sources(beman.exemplar.examples.${example} PRIVATE ${example}.cpp)
+    add_executable(beman-exemplar.examples.${example})
+    target_sources(beman-exemplar.examples.${example} PRIVATE ${example}.cpp)
     target_link_libraries(
-        beman.exemplar.examples.${example}
+        beman-exemplar.examples.${example}
         PRIVATE beman::exemplar
     )
 endforeach()

--- a/src/beman/exemplar/CMakeLists.txt
+++ b/src/beman/exemplar/CMakeLists.txt
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_library(beman.exemplar)
-add_library(beman::exemplar ALIAS beman.exemplar)
+add_library(beman-exemplar)
+add_library(beman::exemplar ALIAS beman-exemplar)
 
-target_sources(beman.exemplar PRIVATE identity.cpp)
+target_sources(beman-exemplar PRIVATE identity.cpp)
 
 target_sources(
-    beman.exemplar
+    beman-exemplar
     PUBLIC
         FILE_SET HEADERS
         BASE_DIRS ${PROJECT_SOURCE_DIR}/include
@@ -14,13 +14,13 @@ target_sources(
 )
 
 set_target_properties(
-    beman.exemplar
+    beman-exemplar
     PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON EXPORT_NAME exemplar
 )
 
 install(
-    TARGETS beman.exemplar
-    EXPORT beman.exemplar
+    TARGETS beman-exemplar
+    EXPORT beman-exemplar
     DESTINATION
     ${CMAKE_INSTALL_LIBDIR}$<$<CONFIG:Debug>:/debug>
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}$<$<CONFIG:Debug>:/debug>
@@ -52,7 +52,7 @@ if(BEMAN_EXEMPLAR_INSTALL_CONFIG_FILE_PACKAGE)
     )
 
     install(
-        EXPORT beman.exemplar
+        EXPORT beman-exemplar
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
         NAMESPACE beman::
         FILE ${PROJECT_NAME}-targets.cmake

--- a/tests/beman/exemplar/CMakeLists.txt
+++ b/tests/beman/exemplar/CMakeLists.txt
@@ -2,12 +2,12 @@
 
 find_package(GTest REQUIRED)
 
-add_executable(beman.exemplar.tests.identity)
-target_sources(beman.exemplar.tests.identity PRIVATE identity.test.cpp)
+add_executable(beman-exemplar.tests.identity)
+target_sources(beman-exemplar.tests.identity PRIVATE identity.test.cpp)
 target_link_libraries(
-    beman.exemplar.tests.identity
+    beman-exemplar.tests.identity
     PRIVATE beman::exemplar GTest::gtest GTest::gtest_main
 )
 
 include(GoogleTest)
-gtest_discover_tests(beman.exemplar.tests.identity)
+gtest_discover_tests(beman-exemplar.tests.identity)


### PR DESCRIPTION
<!--
Please follow our code of conduct when engaging in the Beman community:
https://github.com/bemanproject/beman/blob/main/docs/CODE_OF_CONDUCT.md
-->

<!--
Thank you for your contribution!

If you are updating project structure or build configs:
- Make sure your contribution conforms to the Beman Standard:
  https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md
- For new CMake arguments / presets: please make sure you added appropriate CI tests.

If you are updating documentation:
- Make sure badges and pictures does not impact readability.

If you are updating implementations:
- Make sure you submit appropriate testing.

We encourage small and incremental additions instead of large redesigns.
They are easier and faster to review.
They are also less likely to introduce bugs.

While we do not formally adopt this guide as a standard,
we encourage you to read and consider:
"The CL author’s guide to getting through code review".
https://google.github.io/eng-practices/review/developer/

Regardless, feel free to open a PR on your existing changes.
We appreciate the suggestion and will help out.

Please run pre-commit against your change to comply with our linting rules.
The command to check all files in the directory is:
$ pre-commit run --all-files
-->

<!-- markdownlint-disable-next-line MD041 -->
## Description

Rebrand the export target from `beman.exemplar` to `beman-exemplar` to comply with vcpkg port name requirement.

## Related Issues

<!-- use magic keywords like "fix" to close issues linked to this PR automatically -->
#134 

## Motivation and Context

vcpkg does not allow use of `.` in its port name, which users usually assume is the target name. Using dot as separator everywhere for package naming but for vcpkg packages will cause confusion and make the CMake process error prone. Slash character as separator is more universal.

## Testing

CI passing.

## Meta

<!--
The convention in Beman is for the PR author to merge the PR once it's ready.
You can check this box to indicate that you would like Beman members to merge the PR
for you when appropriate reviews have passed.

Please note that:
1. Stale PR may still be merged by a Beman member,
if you need significant time to work on your PR,
leave a comment and change it's status to draft.
2. If you are not a member of the Beman project,
you may not have the permission necessary to merge your own PR.
-->

- [ ] If all approvals are obtained and the PR is green, any Beman member can merge the PR.

This violates [LIBRARY.NAMES], which is current a recommendation. 

I will bring this up in the next beman sync.

<!-- make sure you run pre-commit before opening a PR -->
