### PR TITLE
Unconditional test target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,13 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
-include(CTestUseLaunchers)
+include(CTest)
 include(FetchContent)
 include(GNUInstallDirs)
 
 add_subdirectory(src/beman/exemplar)
 
 if(BEMAN_EXEMPLAR_BUILD_TESTS)
-    enable_testing()
     add_subdirectory(tests/beman/exemplar)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(
     # targets (e.g., library, executable, etc.).
     DESCRIPTION "A Beman library exemplar"
     LANGUAGES CXX
-    VERSION 0.1.0
+    VERSION 0.2.1
 )
 
 # [CMAKE.SKIP_TESTS]


### PR DESCRIPTION
## Description

Enable the `test` target when `BEMAN_EXEMPLAR_BUILD_TESTS` is `OFF`.

## Motivation and Context

At least when using Ninja from the command-line, the `test` target should always be defined to provide simpler interfaces for consumers, humans and tools alike. What should vary is how many tests are registered to run. Zero is the correct number of tests to run when none are built.

## Testing

Existing CI should cover all supported use cases.

Manual testing with `BEMAN_EXEMPLAR_BUILD_TESTS` set to off was performed.

## Meta

This undoes some of what @purpleKarrot did in #109. I [did suggest](https://github.com/bemanproject/exemplar/pull/109#issuecomment-2629569453) that we document more clearly why we want to use the more arcane pattern and to test the workflows we want to support.

- [x] If all approvals are obtained and the PR is green, any Beman member can merge the PR.