### PR TITLE
Add beman.infra using git subtree and get toolchain files from it

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -60,16 +60,16 @@ jobs:
         platform:
           - description: "Ubuntu GNU"
             os: ubuntu-latest
-            toolchain: "cmake/gnu-toolchain.cmake"
+            toolchain: "infra/cmake/gnu-toolchain.cmake"
           - description: "Ubuntu LLVM"
             os: ubuntu-latest
-            toolchain: "cmake/llvm-toolchain.cmake"
+            toolchain: "infra/cmake/llvm-toolchain.cmake"
           - description: "Windows MSVC"
             os: windows-latest
-            toolchain: "cmake/msvc-toolchain.cmake"
+            toolchain: "infra/cmake/msvc-toolchain.cmake"
           - description: "Macos Appleclang"
             os: macos-latest
-            toolchain: "cmake/appleclang-toolchain.cmake"
+            toolchain: "infra/cmake/appleclang-toolchain.cmake"
         cpp_version: [17, 20, 23, 26]
         cmake_args:
           - description: "Default"
@@ -81,7 +81,7 @@ jobs:
           - platform:
               description: "Ubuntu GCC"
               os: ubuntu-latest
-              toolchain: "cmake/gnu-toolchain.cmake"
+              toolchain: "infra/cmake/gnu-toolchain.cmake"
             cpp_version: 17
             cmake_args:
               description: "Werror"
@@ -89,7 +89,7 @@ jobs:
           - platform:
               description: "Ubuntu GCC"
               os: ubuntu-latest
-              toolchain: "cmake/gnu-toolchain.cmake"
+              toolchain: "infra/cmake/gnu-toolchain.cmake"
             cpp_version: 17
             cmake_args:
               description: "Dynamic"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,7 +35,7 @@
         "_debug-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "cmake/gnu-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/gnu-toolchain.cmake"
       }
     },
     {
@@ -46,7 +46,7 @@
         "_release-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "cmake/gnu-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/gnu-toolchain.cmake"
       }
     },
     {
@@ -57,7 +57,7 @@
         "_debug-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "cmake/llvm-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/llvm-toolchain.cmake"
       }
     },
     {
@@ -68,7 +68,7 @@
         "_release-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "cmake/llvm-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/llvm-toolchain.cmake"
       }
     },
     {
@@ -79,7 +79,7 @@
         "_debug-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "cmake/appleclang-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/appleclang-toolchain.cmake"
       }
     },
     {
@@ -90,7 +90,7 @@
         "_release-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "cmake/appleclang-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/appleclang-toolchain.cmake"
       }
     },
     {
@@ -101,7 +101,7 @@
         "_debug-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "cmake/msvc-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/msvc-toolchain.cmake"
       }
     },
     {
@@ -112,7 +112,7 @@
         "_release-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "cmake/msvc-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/msvc-toolchain.cmake"
       }
     }
   ],

--- a/infra/.devcontainer/docker_dev_container/devcontainer.json
+++ b/infra/.devcontainer/docker_dev_container/devcontainer.json
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+{
+	"name": "beman.infra Docker Devcontainer",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "latest",
+			"enableNonRootDocker": true,
+			"moby": false
+		},
+                "ghcr.io/devcontainers-extra/features/pre-commit:2": {}
+	}
+}

--- a/infra/.github/CODEOWNERS
+++ b/infra/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bemanproject/core-reviewers

--- a/infra/.github/workflows/build_devcontainer.yml
+++ b/infra/.github/workflows/build_devcontainer.yml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: 2.0 license with LLVM exceptions
+
+name: Publish Beman devcontainers
+
+on:
+  push:
+    paths:
+      - ".github/workflows/build_devcontainer.yml"
+      - "devcontainer/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  DEBUG_IMAGE_NAME: ${{ github.repository }}
+  DEPLOY_IMAGE_NAME: beman/devcontainers
+
+permissions:
+  packages: write
+
+jobs:
+  build-and-push-devcontainer-image:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - kind: gnu
+            version: 14
+          - kind: llvm
+            version: 19
+    name: "devcontainer: ${{ matrix.kind }}-${{ matrix.version }}"
+    steps:
+      - name: Compute Image Name
+        id: image_name
+        run: |
+          image_name=${{ env.DEPLOY_IMAGE_NAME }}
+          if [ "${{ github.repository }}/${{ github.ref }}" != "bemanproject/infra/refs/heads/main" ]; then
+              image_name=${{ env.DEBUG_IMAGE_NAME }}
+          fi
+          echo "computed image name: $image_name"
+          echo "image_name=$image_name" >> "$GITHUB_OUTPUT"
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: devcontainer
+          build-args: |
+            compiler_kind=${{ matrix.kind }}
+            compiler_version=${{ matrix.version }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ steps.image_name.outputs.image_name }}:${{ matrix.kind }}-${{ matrix.version }}
+          # https://github.com/docker/build-push-action/issues/894
+          provenance: false

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,32 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,3 @@
+# infra
+
+Internal Beman Project infrastructure repo

--- a/infra/cmake/appleclang-toolchain.cmake
+++ b/infra/cmake/appleclang-toolchain.cmake
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This toolchain file is not meant to be used directly,
+# but to be invoked by CMake preset and GitHub CI.
+#
+# This toolchain file configures for apple clang family of compiler.
+# Note this is different from LLVM toolchain.
+#
+# BEMAN_BUILDSYS_SANITIZER:
+# This optional CMake parameter is not meant for public use and is subject to
+# change.
+# Possible values:
+# - MaxSan: configures clang and clang++ to use all available non-conflicting
+#           sanitizers. Note that apple clang does not support leak sanitizer.
+# - TSan:   configures clang and clang++ to enable the use of thread sanitizer.
+
+include_guard(GLOBAL)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+if(BEMAN_BUILDSYS_SANITIZER STREQUAL "MaxSan")
+    set(SANITIZER_FLAGS
+        "-fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=undefined"
+    )
+elseif(BEMAN_BUILDSYS_SANITIZER STREQUAL "TSan")
+    set(SANITIZER_FLAGS "-fsanitize=thread")
+endif()
+
+set(CMAKE_C_FLAGS_DEBUG_INIT "${SANITIZER_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "${SANITIZER_FLAGS}")
+
+set(RELEASE_FLAGS "-O3 ${SANITIZER_FLAGS}")
+
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
+
+set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")

--- a/infra/cmake/gnu-toolchain.cmake
+++ b/infra/cmake/gnu-toolchain.cmake
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This toolchain file is not meant to be used directly,
+# but to be invoked by CMake preset and GitHub CI.
+#
+# This toolchain file configures for GNU family of compiler.
+#
+# BEMAN_BUILDSYS_SANITIZER:
+# This optional CMake parameter is not meant for public use and is subject to
+# change.
+# Possible values:
+# - MaxSan: configures gcc and g++ to use all available non-conflicting
+#           sanitizers.
+# - TSan:   configures gcc and g++ to enable the use of thread sanitizer
+
+include_guard(GLOBAL)
+
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+if(BEMAN_BUILDSYS_SANITIZER STREQUAL "MaxSan")
+    set(SANITIZER_FLAGS
+        "-fsanitize=address -fsanitize=leak -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=undefined -fsanitize-undefined-trap-on-error"
+    )
+elseif(BEMAN_BUILDSYS_SANITIZER STREQUAL "TSan")
+    set(SANITIZER_FLAGS "-fsanitize=thread")
+endif()
+
+set(CMAKE_C_FLAGS_DEBUG_INIT "${SANITIZER_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "${SANITIZER_FLAGS}")
+
+set(RELEASE_FLAGS "-O3 ${SANITIZER_FLAGS}")
+
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
+
+set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")

--- a/infra/cmake/llvm-toolchain.cmake
+++ b/infra/cmake/llvm-toolchain.cmake
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This toolchain file is not meant to be used directly,
+# but to be invoked by CMake preset and GitHub CI.
+#
+# This toolchain file configures for LLVM family of compiler.
+#
+# BEMAN_BUILDSYS_SANITIZER:
+# This optional CMake parameter is not meant for public use and is subject to
+# change.
+# Possible values:
+# - MaxSan: configures clang and clang++ to use all available non-conflicting
+#           sanitizers.
+# - TSan:   configures clang and clang++ to enable the use of thread sanitizer.
+
+include_guard(GLOBAL)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+if(BEMAN_BUILDSYS_SANITIZER STREQUAL "MaxSan")
+    set(SANITIZER_FLAGS
+        "-fsanitize=address -fsanitize=leak -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=undefined -fsanitize-undefined-trap-on-error"
+    )
+elseif(BEMAN_BUILDSYS_SANITIZER STREQUAL "TSan")
+    set(SANITIZER_FLAGS "-fsanitize=thread")
+endif()
+
+set(CMAKE_C_FLAGS_DEBUG_INIT "${SANITIZER_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "${SANITIZER_FLAGS}")
+
+set(RELEASE_FLAGS "-O3 ${SANITIZER_FLAGS}")
+
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
+
+set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")

--- a/infra/cmake/msvc-toolchain.cmake
+++ b/infra/cmake/msvc-toolchain.cmake
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This toolchain file is not meant to be used directly,
+# but to be invoked by CMake preset and GitHub CI.
+#
+# This toolchain file configures for MSVC family of compiler.
+#
+# BEMAN_BUILDSYS_SANITIZER:
+# This optional CMake parameter is not meant for public use and is subject to
+# change.
+# Possible values:
+# - MaxSan: configures cl to use all available non-conflicting sanitizers.
+#
+# Note that in other toolchain files, TSan is also a possible value for
+# BEMAN_BUILDSYS_SANITIZER, however, MSVC does not support thread sanitizer,
+# thus this value is omitted.
+
+include_guard(GLOBAL)
+
+set(CMAKE_C_COMPILER cl)
+set(CMAKE_CXX_COMPILER cl)
+
+if(BEMAN_BUILDSYS_SANITIZER STREQUAL "MaxSan")
+    # /Zi flag (add debug symbol) is needed when using address sanitizer
+    # See C5072: https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c5072
+    set(SANITIZER_FLAGS "/fsanitize=address /Zi")
+endif()
+
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "/EHsc /permissive- ${SANITIZER_FLAGS}")
+set(CMAKE_C_FLAGS_DEBUG_INIT "/EHsc /permissive- ${SANITIZER_FLAGS}")
+
+set(RELEASE_FLAGS "/EHsc /permissive- /O2 ${SANITIZER_FLAGS}")
+
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
+
+set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")

--- a/infra/devcontainer/Dockerfile
+++ b/infra/devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
+
+USER vscode
+WORKDIR /tmp
+
+# Latest CMake needed for most of the beman libraries,
+# so we need to install via kitware's apt repo
+RUN bash <<EOF
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+    sudo apt-get update && sudo apt-get install -y cmake
+EOF
+
+# Newer gcc/ llvm is needed to avoid ASAN Stalling, which is turned on by default across beman projects.
+# See: https://github.com/google/sanitizers/issues/1614
+# Minimal version: clang-18.1.3, gcc-13.2
+ARG compiler_kind=gnu
+ARG compiler_version=14
+
+COPY install_compiler.sh .
+RUN bash install_compiler.sh ${compiler_kind} ${compiler_version}
+
+# Needed for recent exemplar
+RUN sudo apt-get install -y libgtest-dev
+
+# Pre-commit is beman library's standard linting tool
+RUN sudo apt-get install -y pipx
+RUN pipx install pre-commit
+ENV PATH="/home/vscode/.local/bin:${PATH}"
+
+ENTRYPOINT ["/usr/bin/bash"]

--- a/infra/devcontainer/README.md
+++ b/infra/devcontainer/README.md
@@ -1,0 +1,44 @@
+# Devcontainer
+
+<!-- SPDX-License-Identifier: 2.0 license with LLVM exceptions -->
+
+This folder contains the infrastructure for Beman project's
+generic devcontainer image. You can checkout available images in beman's
+[GitHub Packages page](https://github.com/orgs/bemanproject/packages/container/package/devcontainers).
+
+The image is build on top of GitHub's
+[C++ devcontainer image](https://github.com/devcontainers/images/tree/main/src/cpp)
+for Ubuntu 24.04.
+
+The image includes:
+
+- The latest CMake from kitware's apt repository
+- Latest compiler based on build args (gnu or llvm) installed from the universe repository
+- [pre-commit](https://pre-commit.com/), the standard linter manager across Beman
+
+## Example devcontainer setup
+
+```json
+// SPDX-License-Identifier: 2.0 license with LLVM exceptions
+{
+    "name": "Beman Generic Devcontainer",
+    "image": "ghcr.io/bemanproject/devcontainers:gnu-14",
+    "postCreateCommand": "pre-commit",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "ms-vscode.cmake-tools"
+            ]
+        }
+    }
+}
+```
+
+## Building your own image
+
+You can build your own Beman devcontainer image with:
+
+```bash
+docker build devcontainer/
+```

--- a/infra/devcontainer/install_compiler.sh
+++ b/infra/devcontainer/install_compiler.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -e
+set +x
+TOOL=$1
+VERSION=$2
+
+echo "Install ${TOOL} at: ${VERSION}"
+
+shopt -s nocasematch
+if [ "$TOOL" = "gnu" ]; then
+    sudo apt-get remove -y gcc-"$VERSION" g++-"$VERSION" gcc g++
+    sudo apt-get install -y gcc-"$VERSION" g++-"$VERSION"
+
+    sudo rm -f /usr/bin/gcc
+    sudo rm -f /usr/bin/g++
+
+    sudo ln -s "$(which gcc-"$VERSION")" /usr/bin/gcc
+    sudo ln -s "$(which g++-"$VERSION")" /usr/bin/g++
+
+    gcc --version
+else
+    sudo apt-get install -y lsb-release wget software-properties-common gnupg
+    wget https://apt.llvm.org/llvm.sh
+
+    sudo bash llvm.sh "${VERSION}"
+
+    sudo rm -f /usr/bin/clang
+    sudo rm -f /usr/bin/clang++
+
+    sudo ln -s "$(which clang-"$VERSION")" /usr/bin/clang
+    sudo ln -s "$(which clang++-"$VERSION")" /usr/bin/clang++
+
+    clang --version
+fi


### PR DESCRIPTION
Previously, these toolchain files were part of beman.exemplar, but by
splitting them out into a separate repository, we allow them to be
more easily reused by other Beman repositories, helping us to
distribute changes to the toolchain files and partly mitigating bitrot
of the CMake files after a developer copies them from the exemplar
template.

Add 'infra/' from commit '632053d668dd7a2b67e140ff383ee502e5451d4e'

git-subtree-dir: infra
git-subtree-mainline: https://github.com/bemanproject/exemplar/commit/0a275deb116a07d97dc197c8eda5ff74832e356b
git-subtree-split: https://github.com/bemanproject/exemplar/commit/632053d668dd7a2b67e140ff383ee502e5451d4e