### PR TITLE
Fix IdentityTest compare_std_vs_beman in identity.test.cpp

### DIFF
--- a/tests/beman/exemplar/identity.test.cpp
+++ b/tests/beman/exemplar/identity.test.cpp
@@ -29,7 +29,7 @@ TEST(IdentityTest, call_identity_with_custom_type) {
 
 TEST(IdentityTest, compare_std_vs_beman) {
 // Requires: std::identity support.
-#if defined(__cpp_lib_identity)
+#if defined(__cpp_lib_type_identity)
     std::identity std_id;
     exe::identity beman_id;
     for (int i = -100; i < 100; ++i) {


### PR DESCRIPTION
Feature test macro `__cpp_lib_identity` is wrong. Should be `__cpp_lib_type_identity`.