### PR TITLE
Don't check for appearances of the string "exemplar" in infra/ directory of cookiecutter output

### DIFF
--- a/cookiecutter/check_cookiecutter.sh
+++ b/cookiecutter/check_cookiecutter.sh
@@ -47,6 +47,7 @@ function check_templating() {
         paper="P0898R3" \
         owner="bemanproject" \
         description="A Beman Library RLZrmX9NfS"
+    rm -rf "$out_dir_path/RLZrmX9NfS/infra"
     local grep_path
     grep_path=$(mktemp)
     grep \


### PR DESCRIPTION
Normally, the CI check for cookiecutter attempts to ensure that the string "exemplar" doesn't appear in the cookiecutter output in order to verify that the maintainer didn't miss a template.

However, there are uses of that string for unrelated reasons in infra/, for example:


```
Untemplated "exemplar" in cookiecutter:
/tmp/tmp.HlSzWR1S2v/RLZrmX9NfS/infra/tools/beman-tidy/beman_tidy/lib/utils/string.py-    return name[:6] == "beman." and is_snake_case(name[6:]) and not re.match(".*[0-9]+$", name[6:])
/tmp/tmp.HlSzWR1S2v/RLZrmX9NfS/infra/tools/beman-tidy/beman_tidy/lib/utils/string.py-
/tmp/tmp.HlSzWR1S2v/RLZrmX9NfS/infra/tools/beman-tidy/beman_tidy/lib/utils/string.py-
/tmp/tmp.HlSzWR1S2v/RLZrmX9NfS/infra/tools/beman-tidy/beman_tidy/lib/utils/string.py-def match_badges(string):
/tmp/tmp.HlSzWR1S2v/RLZrmX9NfS/infra/tools/beman-tidy/beman_tidy/lib/utils/string.py-    """
/tmp/tmp.HlSzWR1S2v/RLZrmX9NfS/infra/tools/beman-tidy/beman_tidy/lib/utils/string.py:    e.g., ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
```

This commit addresses the issue by removing the "infra" directory before performing the check.