### PR TITLE
markdownlint: Don't include code blocks in line length check

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -7,3 +7,4 @@ MD033: false
 # Update the comment in .clang-format if we no-longer tie these two column limits.
 MD013:
   line_length: 119
+  code_blocks: false

--- a/cookiecutter/{{cookiecutter.project_name}}/.markdownlint.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.markdownlint.yaml
@@ -7,3 +7,4 @@ MD033: false
 # Update the comment in .clang-format if we no-longer tie these two column limits.
 MD013:
   line_length: 119
+  code_blocks: false


### PR DESCRIPTION
Code blocks can include output from tools that should be displayed exactly as the tool produced it, and which also exceeds the configured line length that we want to use for prose.