### PR TITLE
Add workflow to autoupdate pre-commit

### DIFF
--- a/.github/workflows/update-pre-commit.yml
+++ b/.github/workflows/update-pre-commit.yml
@@ -1,0 +1,29 @@
+name: Pre-commit auto-update
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # Weekly
+  workflow_dispatch:
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-autoupdate
+          title: Auto-update pre-commit hooks
+          commit-message: Auto-update pre-commit hooks
+          body: Update versions of tools in pre-commit configs to latest version
+          labels: dependencies

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/update-pre-commit.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/update-pre-commit.yml
@@ -1,0 +1,29 @@
+name: Pre-commit auto-update
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # Weekly
+  workflow_dispatch:
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-autoupdate
+          title: Auto-update pre-commit hooks
+          commit-message: Auto-update pre-commit hooks
+          body: Update versions of tools in pre-commit configs to latest version
+          labels: dependencies

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/update-pre-commit.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/update-pre-commit.yml
@@ -1,3 +1,4 @@
+{% raw -%}
 name: Pre-commit auto-update
 
 on:
@@ -27,3 +28,4 @@ jobs:
           commit-message: Auto-update pre-commit hooks
           body: Update versions of tools in pre-commit configs to latest version
           labels: dependencies
+{%- endraw %}


### PR DESCRIPTION
## Description

Added a GitHub Actions workflow to auto-update pre-commit.

I'm not sure what frequency we want to run it at. Running it daily felt excessive; right now it's set to run weekly.

## Related Issues

Addresses #164. 

Pinging @wusatosi as the creator of that issue and because it has the "mentoring available" tag.

## Meta

<!--
The convention in Beman is for the PR author to merge the PR once it's ready.
You can check this box to indicate that you would like Beman members to merge the PR
for you when appropriate reviews have passed.

Please note that:
1. Stale PR may still be merged by a Beman member,
if you need significant time to work on your PR,
leave a comment and change it's status to draft.
2. If you are not a member of the Beman project,
you may not have the permission necessary to merge your own PR.
-->

- [x] If all approvals are obtained and the PR is green, any Beman member can merge the PR.

<!-- make sure you run pre-commit before opening a PR -->
