### PR TITLE
Disable Markdown linting by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,11 @@ repos:
 
     # Markdown linting
     # Config file: .markdownlint.yaml
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.42.0
-    hooks:
-    - id: markdownlint
+    # Commented out to disable this by default. Uncomment to enable markdown linting.
+  # - repo: https://github.com/igorshubovych/markdownlint-cli
+  #   rev: v0.42.0
+  #   hooks:
+  #   - id: markdownlint
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -27,10 +27,11 @@ repos:
 
     # Markdown linting
     # Config file: .markdownlint.yaml
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.42.0
-    hooks:
-    - id: markdownlint
+    # Commented out to disable this by default. Uncomment to enable markdown linting.
+  # - repo: https://github.com/igorshubovych/markdownlint-cli
+  #   rev: v0.42.0
+  #   hooks:
+  #   - id: markdownlint
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0


### PR DESCRIPTION
Due to feedback from Beman developers complaining about the noisiness of the warnings produced by markdownlint, at the 2025-06-30 Beman weekly sync the decision was made to disable Markdown linting by default.

