### PR TITLE
Fix duplicative cookiecutter test CI runs

### DIFF
--- a/.github/workflows/cookiecutter_test.yml
+++ b/.github/workflows/cookiecutter_test.yml
@@ -3,6 +3,8 @@
 name: Cookiecutter Test
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Only run cookiecutter tests on pull requests, or on pushes to main.