### PR TITLE
Fix cmake argument passing in cmake-build-test

### DIFF
--- a/.github/actions/cmake-build-test/action.yml
+++ b/.github/actions/cmake-build-test/action.yml
@@ -34,7 +34,7 @@ runs:
           -DCMAKE_CXX_STANDARD=${{ inputs.cpp_version }} \
           -DCMAKE_TOOLCHAIN_FILE="${{ inputs.toolchain_file }}" \
           -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="./infra/cmake/use-fetch-content.cmake" \
-          ${{ matrix.cmake_args.args }}
+          ${{ inputs.cmake_extra_args }}
       env:
         CMAKE_GENERATOR: "Ninja Multi-Config"
     - name: Build Release

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/actions/cmake-build-test/action.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/actions/cmake-build-test/action.yml
@@ -35,7 +35,7 @@ runs:
           -DCMAKE_CXX_STANDARD=${{ inputs.cpp_version }} \
           -DCMAKE_TOOLCHAIN_FILE="${{ inputs.toolchain_file }}" \
           -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="./infra/cmake/use-fetch-content.cmake" \
-          ${{ matrix.cmake_args.args }}
+          ${{ inputs.cmake_extra_args }}
       env:
         CMAKE_GENERATOR: "Ninja Multi-Config"
     - name: Build Release


### PR DESCRIPTION
When 3f9eb62458c332a976939da562658eb099ec9078 moved these into a separate GitHub action, it forgot to update the CMake arguments parameter; this commit addresses that.