### PR TITLE
Fix path for reusable beman pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   pre-commit:
-    uses: ./.github/workflows/beman-reusable-pre-commit.yml
+    uses: ./.github/workflows/reusable-beman-pre-commit.yml

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit.yml
@@ -11,5 +11,5 @@ on:
 
 jobs:
   pre-commit:
-    uses: ./.github/workflows/beman-reusable-pre-commit.yml
+    uses: ./.github/workflows/reusable-beman-pre-commit.yml
 {%- endraw %}


### PR DESCRIPTION
e8070efedbea8e2f0fb0ac0bc0acfd86e54fad67 was merged with an incorrect path for this reusable workflow file, which was missed because the pull request ran with the file that was currently on main.
