### PR TITLE
Add bemanproject/infra-workflows as beman-submodule

### DIFF
--- a/.github/workflows/.beman_submodule
+++ b/.github/workflows/.beman_submodule
@@ -1,0 +1,4 @@
+[beman_submodule]
+remote=https://github.com/bemanproject/infra-workflows.git
+commit_hash=cc68f719c9f41468a38412ed2987090ebc8aa504
+allow_untracked_files=True

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,85 @@
+# Beman Project Reusable Github Actions Repository
+
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+This repository contains [reusable GitHub Actions
+workflows](https://docs.github.com/en/actions/how-tos/sharing-automations/reusing-workflows)
+workflow files, intended to help unify the GitHub Actions machinery used across Beman
+repositories for CI. It contains the following reusable workflows:
+
+## `reusable-beman-build-and-test.yml`
+
+This is the main workflow file used for CI. It takes in a JSON build configuration like
+the following example:
+
+```json
+{
+  "gcc": [
+    { "versions": ["15"],
+      "tests": [
+        { "cxxversions": ["c++26"],
+          "tests": [
+            { "stdlibs": ["libstdc++"],
+              "tests": [
+                "Debug.Default", "Release.Default", "Debug.TSan", "Debug.MaxSan",
+                "Debug.Werror", "Debug.Dynamic"
+              ]
+            }
+          ]
+        },
+        { "cxxversions": ["c++23", "c++20", "c++17"],
+          "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
+        }
+      ]
+    },
+  "clang-p2996": [
+    { "versions": ["trunk"],
+      "tests": [
+        { "cxxversions": ["c++26"],
+          "tests": [{"stdlibs": ["libc++"], "tests": ["Release.-DCMAKE_CXX_FLAGS='-freflection-latest'"]}]
+        }
+      ]
+    }
+  ]
+}
+```
+
+It then runs jobs corresponding to the specified set of configurations.
+
+## `reusable-beman-create-issue-when-fault.yml`
+
+This workflow is intended to help with projects that invoke CI on a scheduled basis when
+those jobs fail. It creates a GitHub issue describing the CI failure.
+
+## `reusable-beman-preset-test.yml`
+
+This workflow is intended to ensure that the CMake presets provided by beman/infra are
+valid and working for the given repository. It takes in a JSON build configuration like
+the following:
+
+```json
+[
+  {"preset": "gcc-debug", "image": "ghcr.io/bemanproject/infra-containers-gcc:latest"},
+  {"preset": "gcc-release", "image": "ghcr.io/bemanproject/infra-containers-gcc:latest"},
+  {"preset": "llvm-debug", "image": "ghcr.io/bemanproject/infra-containers-clang:latest"},
+  {"preset": "llvm-release", "image": "ghcr.io/bemanproject/infra-containers-clang:latest"},
+  {"preset": "appleclang-debug", "runner": "macos-latest"},
+  {"preset": "appleclang-release", "runner": "macos-latest"},
+  {"preset": "msvc-debug", "runner": "windows-latest"},
+  {"preset": "msvc-release", "runner": "windows-latest"}
+]
+```
+
+It then runs jobs corresponding to the specified set of presets.
+
+## `reusable-beman-pre-commit.yml`
+
+This provides a workflow for running the
+[pre-commit](https://github.com/pre-commit/pre-commit) checks Beman libraries use, on pull
+requests and on push.
+
+## `reusable-beman-submodule-check.yml`
+
+This provides a workflow for checking consistency of
+[`beman-submodule`](https://github.com/bemanproject/infra/blob/main/tools/beman-submodule/README.md)
+directories used by Beman repositories to deduplicate infrastructure.

--- a/cookiecutter/cookiecutter.json
+++ b/cookiecutter/cookiecutter.json
@@ -5,6 +5,7 @@
   "owner": "github-user-name",
   "description": "Short project description.",
   "_copy_without_render": [
-    "infra"
+    "infra",
+    ".github/workflows"
   ]
 }

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/.beman_submodule
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/.beman_submodule
@@ -1,0 +1,4 @@
+[beman_submodule]
+remote=https://github.com/bemanproject/infra-workflows.git
+commit_hash=cc68f719c9f41468a38412ed2987090ebc8aa504
+allow_untracked_files=True

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/README.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/README.md
@@ -1,0 +1,85 @@
+# Beman Project Reusable Github Actions Repository
+
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+This repository contains [reusable GitHub Actions
+workflows](https://docs.github.com/en/actions/how-tos/sharing-automations/reusing-workflows)
+workflow files, intended to help unify the GitHub Actions machinery used across Beman
+repositories for CI. It contains the following reusable workflows:
+
+## `reusable-beman-build-and-test.yml`
+
+This is the main workflow file used for CI. It takes in a JSON build configuration like
+the following example:
+
+```json
+{
+  "gcc": [
+    { "versions": ["15"],
+      "tests": [
+        { "cxxversions": ["c++26"],
+          "tests": [
+            { "stdlibs": ["libstdc++"],
+              "tests": [
+                "Debug.Default", "Release.Default", "Debug.TSan", "Debug.MaxSan",
+                "Debug.Werror", "Debug.Dynamic"
+              ]
+            }
+          ]
+        },
+        { "cxxversions": ["c++23", "c++20", "c++17"],
+          "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
+        }
+      ]
+    },
+  "clang-p2996": [
+    { "versions": ["trunk"],
+      "tests": [
+        { "cxxversions": ["c++26"],
+          "tests": [{"stdlibs": ["libc++"], "tests": ["Release.-DCMAKE_CXX_FLAGS='-freflection-latest'"]}]
+        }
+      ]
+    }
+  ]
+}
+```
+
+It then runs jobs corresponding to the specified set of configurations.
+
+## `reusable-beman-create-issue-when-fault.yml`
+
+This workflow is intended to help with projects that invoke CI on a scheduled basis when
+those jobs fail. It creates a GitHub issue describing the CI failure.
+
+## `reusable-beman-preset-test.yml`
+
+This workflow is intended to ensure that the CMake presets provided by beman/infra are
+valid and working for the given repository. It takes in a JSON build configuration like
+the following:
+
+```json
+[
+  {"preset": "gcc-debug", "image": "ghcr.io/bemanproject/infra-containers-gcc:latest"},
+  {"preset": "gcc-release", "image": "ghcr.io/bemanproject/infra-containers-gcc:latest"},
+  {"preset": "llvm-debug", "image": "ghcr.io/bemanproject/infra-containers-clang:latest"},
+  {"preset": "llvm-release", "image": "ghcr.io/bemanproject/infra-containers-clang:latest"},
+  {"preset": "appleclang-debug", "runner": "macos-latest"},
+  {"preset": "appleclang-release", "runner": "macos-latest"},
+  {"preset": "msvc-debug", "runner": "windows-latest"},
+  {"preset": "msvc-release", "runner": "windows-latest"}
+]
+```
+
+It then runs jobs corresponding to the specified set of presets.
+
+## `reusable-beman-pre-commit.yml`
+
+This provides a workflow for running the
+[pre-commit](https://github.com/pre-commit/pre-commit) checks Beman libraries use, on pull
+requests and on push.
+
+## `reusable-beman-submodule-check.yml`
+
+This provides a workflow for checking consistency of
+[`beman-submodule`](https://github.com/bemanproject/infra/blob/main/tools/beman-submodule/README.md)
+directories used by Beman repositories to deduplicate infrastructure.

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 name: Continuous Integration Tests
@@ -142,4 +141,3 @@ jobs:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'
     uses: ./.github/workflows/reusable-beman-create-issue-when-fault.yml
-{%- endraw %}

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 name: Lint Check (pre-commit)
 
 on:
@@ -12,4 +11,3 @@ on:
 jobs:
   pre-commit:
     uses: ./.github/workflows/reusable-beman-pre-commit.yml
-{%- endraw %}

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-build-and-test.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-build-and-test.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 name: 'Beman build-and-test matrix'
@@ -145,4 +144,3 @@ jobs:
       - name: Test
         shell: bash
         run: ctest --test-dir build --build-config ${{ steps.vars.outputs.build_config }} --output-on-failure
-{%- endraw %}

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-create-issue-when-fault.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-create-issue-when-fault.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 name: 'Beman issue creation workflow'
@@ -29,4 +28,3 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
-{%- endraw %}

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-pre-commit.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-pre-commit.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 name: 'Beman pre-commit check'
@@ -72,4 +71,3 @@ jobs:
           tool_name: pre-commit
           level: warning
           reviewdog_flags: "-fail-level=error"
-{%- endraw %}

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-preset-test.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-preset-test.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 name: 'Beman preset test matrix'
@@ -32,4 +31,3 @@ jobs:
           arch: x64
       - name: Run preset
         run: cmake --workflow --preset ${{ matrix.presets.preset }}
-{%- endraw %}

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-submodule-check.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-submodule-check.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 name: 'beman-submodule check'
@@ -19,4 +18,3 @@ jobs:
       - name: beman submodule consistency check
         run: |
           (set -o pipefail; ${{ inputs.infra_path }}/tools/beman-submodule/beman-submodule status | grep -qvF '+')
-{%- endraw %}


### PR DESCRIPTION
This new beman-submodule repository allows us to reuse GitHub Actions workflows between multiple beman projects while maintaining a single source of truth to prevent them from getting out of sync.

Ideally, these would live inside the infra/ repository and be symlinked into the .github directory, but GitHub Actions does not follow symlinks, necessitating a separate repository.
