### PR TITLE
Remove raw/endraw tags from update-pre-commit workflow

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/update-pre-commit.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/update-pre-commit.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 name: Pre-commit auto-update
 
 on:
@@ -28,4 +27,3 @@ jobs:
           commit-message: Auto-update pre-commit hooks
           body: Update versions of tools in pre-commit configs to latest version
           labels: dependencies
-{%- endraw %}


### PR DESCRIPTION
These were rendered superfluous and broke CI due to a bad rebase across commit 4a769b47.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/CODE_OF_CONDUCT.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md
-->
