### PR TITLE
Move update-pre-commit workflow logic into reusable workflow file

### DIFF
--- a/.github/workflows/.beman_submodule
+++ b/.github/workflows/.beman_submodule
@@ -1,4 +1,4 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra-workflows.git
-commit_hash=98ded91029b883e56b61b320d021e2d3095e7802
+commit_hash=51b9bf5a86a40dbf0cf746429ada367e322c0bf0
 allow_untracked_files=True

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '30 15 * * *'
+    - cron: "0 0 * * 0"
 
 jobs:
   beman-submodule-check:
@@ -136,5 +137,9 @@ jobs:
 
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
-    if: failure() && github.event_name == 'schedule'
+    if: failure() && github.event.schedule == '30 15 * * *'
     uses: ./.github/workflows/reusable-beman-create-issue-when-fault.yml
+
+  auto-update-pre-commit:
+    if: github.event.schedule == '00 16 * * 0'
+    uses: ./.github/workflows/reusable-beman-update-pre-commit.yml

--- a/.github/workflows/reusable-beman-update-pre-commit.yml
+++ b/.github/workflows/reusable-beman-update-pre-commit.yml
@@ -1,9 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 name: Pre-commit auto-update
 
 on:
-  schedule:
-    - cron: "0 0 * * 0"  # Weekly
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   auto-update:

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/.beman_submodule
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/.beman_submodule
@@ -1,4 +1,4 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra-workflows.git
-commit_hash=98ded91029b883e56b61b320d021e2d3095e7802
+commit_hash=51b9bf5a86a40dbf0cf746429ada367e322c0bf0
 allow_untracked_files=True

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '30 15 * * *'
+    - cron: "0 0 * * 0"
 
 jobs:
   beman-submodule-check:
@@ -136,5 +137,9 @@ jobs:
 
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
-    if: failure() && github.event_name == 'schedule'
+    if: failure() && github.event.schedule == '30 15 * * *'
     uses: ./.github/workflows/reusable-beman-create-issue-when-fault.yml
+
+  auto-update-pre-commit:
+    if: github.event.schedule == '00 16 * * 0'
+    uses: ./.github/workflows/reusable-beman-update-pre-commit.yml

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-update-pre-commit.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-update-pre-commit.yml
@@ -1,9 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 name: Pre-commit auto-update
 
 on:
-  schedule:
-    - cron: "0 0 * * 0"  # Weekly
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   auto-update:


### PR DESCRIPTION
Moving this workflow into the infra-workflows beman-submodule makes it easier to keep it up to date using beman-submodule updates.

This preserves the weekly schedule of the workflow by adding an additional schedule to ci_tests.yml.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/CODE_OF_CONDUCT.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md
-->
