### PR TITLE
Call beman_install_library

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,12 @@ To configure, build and test the project with extra arguments,
 you can run this set of commands.
 
 ```bash
-cmake -B build -S . -DCMAKE_CXX_STANDARD=20 # Your extra arguments here.
+cmake \
+  -B build \
+  -S . \
+  -DCMAKE_CXX_STANDARD=20 \
+  -DCMAKE_PREFIX_PATH=./infra/cmake \
+  # Your extra arguments here.
 cmake --build build
 ctest --test-dir build
 ```
@@ -254,6 +259,14 @@ ctest --test-dir build
 > therefore,
 > you will need to specify the C++ version via `CMAKE_CXX_STANDARD`
 > when manually configuring the project.
+
+
+> [!NOTE]
+>
+> You only need to set `CMAKE_PREFIX_PATH` if you want to use the
+> CMake modules provided in the `infra/` directory of this repository.
+> If you have those modules packaged in your environment, you can install
+> them with your package manager and omit this argument.
 
 ### Finding and Fetching GTest from GitHub
 

--- a/cookiecutter/{{cookiecutter.project_name}}/README.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/README.md
@@ -242,7 +242,12 @@ To configure, build and test the project with extra arguments,
 you can run this set of commands.
 
 ```bash
-cmake -B build -S . -DCMAKE_CXX_STANDARD=20 # Your extra arguments here.
+cmake \
+  -B build \
+  -S . \
+  -DCMAKE_CXX_STANDARD=20 \
+  -DCMAKE_PREFIX_PATH=./infra/cmake \
+  # Your extra arguments here.
 cmake --build build
 ctest --test-dir build
 ```
@@ -254,6 +259,14 @@ ctest --test-dir build
 > therefore,
 > you will need to specify the C++ version via `CMAKE_CXX_STANDARD`
 > when manually configuring the project.
+
+
+> [!NOTE]
+>
+> You only need to set `CMAKE_PREFIX_PATH` if you want to use the
+> CMake modules provided in the `infra/` directory of this repository.
+> If you have those modules packaged in your environment, you can install
+> them with your package manager and omit this argument.
 
 ### Finding and Fetching GTest from GitHub
 

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=d7c51d169860c5ceeb8a026859bd24820ab6826d
+commit_hash=d237020a5eeac168f3dc3f617fda8bbf5ca9a6d9

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/appleclang-toolchain.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/appleclang-toolchain.cmake
@@ -39,3 +39,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/beman-install-library-config.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/beman-install-library-config.cmake
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+include_guard(GLOBAL)
+
+# This file defines the function `beman_install_library` which is used to
+# install a library target and its headers, along with optional CMake
+# configuration files.
+#
+# The function is designed to be reusable across different Beman libraries.
+
+function(beman_install_library name)
+    # Usage
+    # -----
+    #
+    #     beman_install_library(NAME)
+    #
+    # Brief
+    # -----
+    #
+    # This function installs the specified library target and its headers.
+    # It also handles the installation of the CMake configuration files if needed.
+    #
+    # CMake variables
+    # ---------------
+    #
+    # Note that configuration of the installation is generally controlled by CMake
+    # cache variables so that they can be controlled by the user or tool running the
+    # `cmake` command. Neither `CMakeLists.txt` nor `*.cmake` files should set these
+    # variables directly.
+    #
+    # - BEMAN_INSTALL_CONFIG_FILE_PACKAGES:
+    #      List of packages that require config file installation.
+    #      If the package name is in this list, it will install the config file.
+    #
+    # - <PREFIX>_INSTALL_CONFIG_FILE_PACKAGE:
+    #      Boolean to control config file installation for the specific library.
+    #      The prefix `<PREFIX>` is the uppercased name of the library with dots
+    #      replaced by underscores.
+    #
+    if(NOT TARGET "${name}")
+        message(FATAL_ERROR "Target '${name}' does not exist.")
+    endif()
+
+    if(NOT ARGN STREQUAL "")
+        message(
+            FATAL_ERROR
+            "beman_install_library does not accept extra arguments: ${ARGN}"
+        )
+    endif()
+
+    # Given foo.bar, the component name is bar
+    string(REPLACE "." ";" name_parts "${name}")
+    # fail if the name doesn't look like foo.bar
+    list(LENGTH name_parts name_parts_length)
+    if(NOT name_parts_length EQUAL 2)
+        message(
+            FATAL_ERROR
+            "beman_install_library expects a name of the form 'beman.<name>', got '${name}'"
+        )
+    endif()
+
+    set(target_name "${name}")
+    set(install_component_name "${name}")
+    set(export_name "${name}")
+    set(package_name "${name}")
+    list(GET name_parts -1 component_name)
+
+    install(
+        TARGETS "${target_name}" COMPONENT "${install_component_name}"
+        EXPORT "${export_name}"
+        FILE_SET HEADERS
+    )
+
+    set_target_properties(
+        "${target_name}"
+        PROPERTIES EXPORT_NAME "${component_name}"
+    )
+
+    include(GNUInstallDirs)
+
+    # Determine the prefix for project-specific variables
+    string(TOUPPER "${name}" project_prefix)
+    string(REPLACE "." "_" project_prefix "${project_prefix}")
+
+    if(
+        "${name}" IN_LIST BEMAN_INSTALL_CONFIG_FILE_PACKAGES
+        OR "${project_prefix}_INSTALL_CONFIG_FILE_PACKAGE"
+    )
+        set(install_config_package ON)
+    endif()
+
+    if(install_config_package)
+        message(
+            DEBUG
+            "beman-install-library: Installing a config package for '${name}'"
+        )
+
+        include(CMakePackageConfigHelpers)
+
+        find_file(
+            config_file_template
+            NAMES "${package_name}-config.cmake.in"
+            PATHS "${CMAKE_CURRENT_SOURCE_DIR}"
+            NO_DEFAULT_PATH
+            NO_CACHE
+            REQUIRED
+        )
+        set(config_package_file
+            "${CMAKE_CURRENT_BINARY_DIR}/${package_name}-config.cmake"
+        )
+        set(package_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${package_name}")
+        configure_package_config_file(
+            "${config_file_template}"
+            "${config_package_file}"
+            INSTALL_DESTINATION "${package_install_dir}"
+            PATH_VARS PROJECT_NAME PROJECT_VERSION
+        )
+
+        set(config_version_file
+            "${CMAKE_CURRENT_BINARY_DIR}/${package_name}-config-version.cmake"
+        )
+        write_basic_package_version_file(
+            "${config_version_file}"
+            VERSION "${PROJECT_VERSION}"
+            COMPATIBILITY ExactVersion
+        )
+
+        install(
+            FILES "${config_package_file}" "${config_version_file}"
+            DESTINATION "${package_install_dir}"
+            COMPONENT "${install_component_name}"
+        )
+
+        set(config_targets_file "${package_name}-targets.cmake")
+        install(
+            EXPORT "${export_name}"
+            DESTINATION "${package_install_dir}"
+            NAMESPACE beman::
+            FILE "${config_targets_file}"
+            COMPONENT "${install_component_name}"
+        )
+    else()
+        message(
+            DEBUG
+            "beman-install-library: Not installing a config package for '${name}'"
+        )
+    endif()
+endfunction()

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/gnu-toolchain.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/gnu-toolchain.cmake
@@ -36,3 +36,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/llvm-toolchain.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/llvm-toolchain.cmake
@@ -36,3 +36,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/msvc-toolchain.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/msvc-toolchain.cmake
@@ -36,3 +36,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/use-fetch-content.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/use-fetch-content.cmake
@@ -152,7 +152,11 @@ function(BemanExemplar_provideDependency method package_name)
                     APPEND
                     BemanExemplar_debug
                     "Redirecting find_package calls for ${BemanExemplar_pkgName} "
-                    "to FetchContent logic fetching ${BemanExemplar_repo} at "
+                    "to FetchContent logic.\n"
+                    string
+                    APPEND
+                    BemanExemplar_debug
+                    "Fetching ${BemanExemplar_repo} at "
                     "${BemanExemplar_tag} according to ${BemanExemplar_lockfile}."
                 )
                 message(DEBUG "${BemanExemplar_debug}")
@@ -177,3 +181,6 @@ cmake_language(
     SET_DEPENDENCY_PROVIDER BemanExemplar_provideDependency
     SUPPORTED_METHODS FIND_PACKAGE
 )
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/cookiecutter/{{cookiecutter.project_name}}/src/beman/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/src/beman/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-include(GNUInstallDirs)
-
 add_library(beman.{{cookiecutter.project_name}})
 add_library(beman::{{cookiecutter.project_name}} ALIAS beman.{{cookiecutter.project_name}})
 
@@ -11,54 +9,12 @@ target_sources(
     beman.{{cookiecutter.project_name}}
     PUBLIC
         FILE_SET HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
+        BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../include"
         FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/beman/{{cookiecutter.project_name}}/identity.hpp
+            "${CMAKE_CURRENT_SOURCE_DIR}/../../../include/beman/{{cookiecutter.project_name}}/identity.hpp"
 )
 
-set_target_properties(
-    beman.{{cookiecutter.project_name}}
-    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON EXPORT_NAME {{cookiecutter.project_name}}
-)
+set_target_properties(beman.{{cookiecutter.project_name}} PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
 
-install(
-    TARGETS beman.{{cookiecutter.project_name}} COMPONENT beman.{{cookiecutter.project_name}}
-    EXPORT beman.{{cookiecutter.project_name}}
-    DESTINATION
-    ${CMAKE_INSTALL_LIBDIR}$<$<CONFIG:Debug>:/debug>
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}$<$<CONFIG:Debug>:/debug>
-    FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-if(BEMAN_{{cookiecutter.project_name.upper()}}_INSTALL_CONFIG_FILE_PACKAGE)
-    include(CMakePackageConfigHelpers)
-
-    configure_package_config_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/beman.{{cookiecutter.project_name}}-config.cmake.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/beman.{{cookiecutter.project_name}}-config.cmake"
-        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/beman.{{cookiecutter.project_name}}"
-        PATH_VARS PROJECT_NAME PROJECT_VERSION
-    )
-
-    write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/beman.{{cookiecutter.project_name}}-config-version.cmake"
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY ExactVersion
-    )
-
-    install(
-        FILES
-            "${CMAKE_CURRENT_BINARY_DIR}/beman.{{cookiecutter.project_name}}-config.cmake"
-            "${CMAKE_CURRENT_BINARY_DIR}/beman.{{cookiecutter.project_name}}-config-version.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/beman.{{cookiecutter.project_name}}"
-        COMPONENT beman.{{cookiecutter.project_name}}
-    )
-
-    install(
-        EXPORT beman.{{cookiecutter.project_name}}
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/beman.{{cookiecutter.project_name}}"
-        NAMESPACE beman::
-        FILE beman.{{cookiecutter.project_name}}-targets.cmake
-        COMPONENT beman.{{cookiecutter.project_name}}
-    )
-endif()
+find_package(beman-install-library REQUIRED)
+beman_install_library(beman.{{cookiecutter.project_name}})

--- a/infra/.beman_submodule
+++ b/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=d7c51d169860c5ceeb8a026859bd24820ab6826d
+commit_hash=d237020a5eeac168f3dc3f617fda8bbf5ca9a6d9

--- a/infra/cmake/appleclang-toolchain.cmake
+++ b/infra/cmake/appleclang-toolchain.cmake
@@ -39,3 +39,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/infra/cmake/beman-install-library-config.cmake
+++ b/infra/cmake/beman-install-library-config.cmake
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+include_guard(GLOBAL)
+
+# This file defines the function `beman_install_library` which is used to
+# install a library target and its headers, along with optional CMake
+# configuration files.
+#
+# The function is designed to be reusable across different Beman libraries.
+
+function(beman_install_library name)
+    # Usage
+    # -----
+    #
+    #     beman_install_library(NAME)
+    #
+    # Brief
+    # -----
+    #
+    # This function installs the specified library target and its headers.
+    # It also handles the installation of the CMake configuration files if needed.
+    #
+    # CMake variables
+    # ---------------
+    #
+    # Note that configuration of the installation is generally controlled by CMake
+    # cache variables so that they can be controlled by the user or tool running the
+    # `cmake` command. Neither `CMakeLists.txt` nor `*.cmake` files should set these
+    # variables directly.
+    #
+    # - BEMAN_INSTALL_CONFIG_FILE_PACKAGES:
+    #      List of packages that require config file installation.
+    #      If the package name is in this list, it will install the config file.
+    #
+    # - <PREFIX>_INSTALL_CONFIG_FILE_PACKAGE:
+    #      Boolean to control config file installation for the specific library.
+    #      The prefix `<PREFIX>` is the uppercased name of the library with dots
+    #      replaced by underscores.
+    #
+    if(NOT TARGET "${name}")
+        message(FATAL_ERROR "Target '${name}' does not exist.")
+    endif()
+
+    if(NOT ARGN STREQUAL "")
+        message(
+            FATAL_ERROR
+            "beman_install_library does not accept extra arguments: ${ARGN}"
+        )
+    endif()
+
+    # Given foo.bar, the component name is bar
+    string(REPLACE "." ";" name_parts "${name}")
+    # fail if the name doesn't look like foo.bar
+    list(LENGTH name_parts name_parts_length)
+    if(NOT name_parts_length EQUAL 2)
+        message(
+            FATAL_ERROR
+            "beman_install_library expects a name of the form 'beman.<name>', got '${name}'"
+        )
+    endif()
+
+    set(target_name "${name}")
+    set(install_component_name "${name}")
+    set(export_name "${name}")
+    set(package_name "${name}")
+    list(GET name_parts -1 component_name)
+
+    install(
+        TARGETS "${target_name}" COMPONENT "${install_component_name}"
+        EXPORT "${export_name}"
+        FILE_SET HEADERS
+    )
+
+    set_target_properties(
+        "${target_name}"
+        PROPERTIES EXPORT_NAME "${component_name}"
+    )
+
+    include(GNUInstallDirs)
+
+    # Determine the prefix for project-specific variables
+    string(TOUPPER "${name}" project_prefix)
+    string(REPLACE "." "_" project_prefix "${project_prefix}")
+
+    if(
+        "${name}" IN_LIST BEMAN_INSTALL_CONFIG_FILE_PACKAGES
+        OR "${project_prefix}_INSTALL_CONFIG_FILE_PACKAGE"
+    )
+        set(install_config_package ON)
+    endif()
+
+    if(install_config_package)
+        message(
+            DEBUG
+            "beman-install-library: Installing a config package for '${name}'"
+        )
+
+        include(CMakePackageConfigHelpers)
+
+        find_file(
+            config_file_template
+            NAMES "${package_name}-config.cmake.in"
+            PATHS "${CMAKE_CURRENT_SOURCE_DIR}"
+            NO_DEFAULT_PATH
+            NO_CACHE
+            REQUIRED
+        )
+        set(config_package_file
+            "${CMAKE_CURRENT_BINARY_DIR}/${package_name}-config.cmake"
+        )
+        set(package_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${package_name}")
+        configure_package_config_file(
+            "${config_file_template}"
+            "${config_package_file}"
+            INSTALL_DESTINATION "${package_install_dir}"
+            PATH_VARS PROJECT_NAME PROJECT_VERSION
+        )
+
+        set(config_version_file
+            "${CMAKE_CURRENT_BINARY_DIR}/${package_name}-config-version.cmake"
+        )
+        write_basic_package_version_file(
+            "${config_version_file}"
+            VERSION "${PROJECT_VERSION}"
+            COMPATIBILITY ExactVersion
+        )
+
+        install(
+            FILES "${config_package_file}" "${config_version_file}"
+            DESTINATION "${package_install_dir}"
+            COMPONENT "${install_component_name}"
+        )
+
+        set(config_targets_file "${package_name}-targets.cmake")
+        install(
+            EXPORT "${export_name}"
+            DESTINATION "${package_install_dir}"
+            NAMESPACE beman::
+            FILE "${config_targets_file}"
+            COMPONENT "${install_component_name}"
+        )
+    else()
+        message(
+            DEBUG
+            "beman-install-library: Not installing a config package for '${name}'"
+        )
+    endif()
+endfunction()

--- a/infra/cmake/gnu-toolchain.cmake
+++ b/infra/cmake/gnu-toolchain.cmake
@@ -36,3 +36,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/infra/cmake/llvm-toolchain.cmake
+++ b/infra/cmake/llvm-toolchain.cmake
@@ -36,3 +36,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/infra/cmake/msvc-toolchain.cmake
+++ b/infra/cmake/msvc-toolchain.cmake
@@ -36,3 +36,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/infra/cmake/use-fetch-content.cmake
+++ b/infra/cmake/use-fetch-content.cmake
@@ -152,7 +152,11 @@ function(BemanExemplar_provideDependency method package_name)
                     APPEND
                     BemanExemplar_debug
                     "Redirecting find_package calls for ${BemanExemplar_pkgName} "
-                    "to FetchContent logic fetching ${BemanExemplar_repo} at "
+                    "to FetchContent logic.\n"
+                    string
+                    APPEND
+                    BemanExemplar_debug
+                    "Fetching ${BemanExemplar_repo} at "
                     "${BemanExemplar_tag} according to ${BemanExemplar_lockfile}."
                 )
                 message(DEBUG "${BemanExemplar_debug}")
@@ -177,3 +181,6 @@ cmake_language(
     SET_DEPENDENCY_PROVIDER BemanExemplar_provideDependency
     SUPPORTED_METHODS FIND_PACKAGE
 )
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/src/beman/exemplar/CMakeLists.txt
+++ b/src/beman/exemplar/CMakeLists.txt
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-include(GNUInstallDirs)
-
 add_library(beman.exemplar)
 add_library(beman::exemplar ALIAS beman.exemplar)
 
@@ -11,54 +9,12 @@ target_sources(
     beman.exemplar
     PUBLIC
         FILE_SET HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
+        BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../include"
         FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/beman/exemplar/identity.hpp
+            "${CMAKE_CURRENT_SOURCE_DIR}/../../../include/beman/exemplar/identity.hpp"
 )
 
-set_target_properties(
-    beman.exemplar
-    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON EXPORT_NAME exemplar
-)
+set_target_properties(beman.exemplar PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
 
-install(
-    TARGETS beman.exemplar COMPONENT beman.exemplar
-    EXPORT beman.exemplar
-    DESTINATION
-    ${CMAKE_INSTALL_LIBDIR}$<$<CONFIG:Debug>:/debug>
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}$<$<CONFIG:Debug>:/debug>
-    FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-if(BEMAN_EXEMPLAR_INSTALL_CONFIG_FILE_PACKAGE)
-    include(CMakePackageConfigHelpers)
-
-    configure_package_config_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/beman.exemplar-config.cmake.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/beman.exemplar-config.cmake"
-        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/beman.exemplar"
-        PATH_VARS PROJECT_NAME PROJECT_VERSION
-    )
-
-    write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/beman.exemplar-config-version.cmake"
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY ExactVersion
-    )
-
-    install(
-        FILES
-            "${CMAKE_CURRENT_BINARY_DIR}/beman.exemplar-config.cmake"
-            "${CMAKE_CURRENT_BINARY_DIR}/beman.exemplar-config-version.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/beman.exemplar"
-        COMPONENT beman.exemplar
-    )
-
-    install(
-        EXPORT beman.exemplar
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/beman.exemplar"
-        NAMESPACE beman::
-        FILE beman.exemplar-targets.cmake
-        COMPONENT beman.exemplar
-    )
-endif()
+find_package(beman-install-library REQUIRED)
+beman_install_library(beman.exemplar)


### PR DESCRIPTION
Problem
-------

The complexity required per project to configure install logic is too high. It is also too decentralized, making it difficult to improve the various Beman repos packaging logic over time.

Solution
--------

Call `beman_install_library` instead. This function will provide reusable installation logic based on Beman Standards.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/CODE_OF_CONDUCT.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md
-->
