### PR TITLE
Remove note about omitting CMAKE_PREFIX_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,14 +260,6 @@ ctest --test-dir build
 > you will need to specify the C++ version via `CMAKE_CXX_STANDARD`
 > when manually configuring the project.
 
-
-> [!NOTE]
->
-> You only need to set `CMAKE_PREFIX_PATH` if you want to use the
-> CMake modules provided in the `infra/` directory of this repository.
-> If you have those modules packaged in your environment, you can install
-> them with your package manager and omit this argument.
-
 ### Finding and Fetching GTest from GitHub
 
 If you do not have GoogleTest installed on your development system, you may

--- a/cookiecutter/{{cookiecutter.project_name}}/README.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/README.md
@@ -260,14 +260,6 @@ ctest --test-dir build
 > you will need to specify the C++ version via `CMAKE_CXX_STANDARD`
 > when manually configuring the project.
 
-
-> [!NOTE]
->
-> You only need to set `CMAKE_PREFIX_PATH` if you want to use the
-> CMake modules provided in the `infra/` directory of this repository.
-> If you have those modules packaged in your environment, you can install
-> them with your package manager and omit this argument.
-
 ### Finding and Fetching GTest from GitHub
 
 If you do not have GoogleTest installed on your development system, you may


### PR DESCRIPTION
This states that if the user has already installed a packaged version of `infra/cmake/beman-install-library-config.cmake`, they can omit `-DCMAKE_PREFIX_PATH=./infra/cmake`. However, no such packaged version exists; the only way to use it currently is through the vendored copy, so this note is not useful in practice. We can restore it when `beman-install-library-config` is packaged.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
