### PR TITLE
Pre-commit autoupdate refactor and infra-workflows version bump

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,14 +10,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '30 15 * * *'
-    - cron: "0 16 * * 0"
 
 jobs:
   beman-submodule-check:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.0.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.1.0
 
   preset-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.0.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.1.0
     with:
       matrix_config: >
         [
@@ -32,7 +31,7 @@ jobs:
         ]
 
   build-and-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.0.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.1.0
     with:
       matrix_config: >
         {
@@ -137,9 +136,5 @@ jobs:
 
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
-    if: failure() && github.event.schedule == '30 15 * * *'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.0.0
-
-  auto-update-pre-commit:
-    if: github.event.schedule == '00 16 * * 0'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.0.0
+    if: failure() && github.event_name == 'schedule'
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0

--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.0.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.1.0

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Weekly pre-commit autoupdate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 16 * * 0"
+
+jobs:
+  auto-update-pre-commit:
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.1.0
+    secrets:
+      APP_ID: ${{ secrets.AUTO_PR_BOT_APP_ID }}
+      PRIVATE_KEY: ${{ secrets.AUTO_PR_BOT_PRIVATE_KEY }}

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -10,14 +10,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '30 15 * * *'
-    - cron: "0 16 * * 0"
 
 jobs:
   beman-submodule-check:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.0.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.1.0
 
   preset-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.0.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.1.0
     with:
       matrix_config: >
         [
@@ -32,7 +31,7 @@ jobs:
         ]
 
   build-and-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.0.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.1.0
     with:
       matrix_config: >
         {
@@ -137,9 +136,5 @@ jobs:
 
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
-    if: failure() && github.event.schedule == '30 15 * * *'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.0.0
-
-  auto-update-pre-commit:
-    if: github.event.schedule == '00 16 * * 0'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.0.0
+    if: failure() && github.event_name == 'schedule'
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-check.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-check.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.0.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.1.0

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-update.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-update.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Weekly pre-commit autoupdate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 16 * * 0"
+
+jobs:
+  auto-update-pre-commit:
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.1.0
+    secrets:
+      APP_ID: ${{ secrets.AUTO_PR_BOT_APP_ID }}
+      PRIVATE_KEY: ${{ secrets.AUTO_PR_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
This commit makes the following changes to pre-commit autoupdate:

- Previously, the scheduling logic in ci_tests.yml was broken due to trying to juggle multiple crons intended for different purposes. This commit addresses the issue by moving the pre-commit autoupdate job into a separate workflow file with its own cron.

- Previously, pull requests created with pre-commit autoupdate would not run CI. This was addressed by using a GitHub token generated by a GitHub App.

- Previously, potentially flaky coverage builds would run during scheduled builds. Coverage is now excluded from these builds after updating infra-workflows.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
